### PR TITLE
FSH Update 1507 - Quickbuff enhancements, New online players etc.

### DIFF
--- a/calfSystem.css
+++ b/calfSystem.css
@@ -17,6 +17,9 @@
 .HelperTableRow2:hover {background-color:white}
 
 .reportLink {cursor:pointer; text-decoration:underline; color:blue;}
+.fshLink {cursor:pointer; text-decoration:underline;}
+.fshRed {color:red;}
+.fshBlue {color:blue}
 .fshNoWrap {white-space: nowrap;}
 .helperQC {cursor: pointer;}
 
@@ -31,8 +34,20 @@ table.relicT td.brn {color:brown;}
 table.relicT td.grey {color:grey;}
 table.relicT td.headr {font-size:small;border-top:2px black solid;}
 
+img.center {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
 
+td.lvlHighlight {
+  background-color:#4671C8;
+}
 
+span#fshRefresh {
+  text-decoration: underline;
+  cursor: pointer;
+}
 
 div#fshCompConf {
   position: relative;
@@ -40,6 +55,10 @@ div#fshCompConf {
   text-align: right;
   padding-right: 38px;
 }
+
+div#quickbuff div#players h1 {float: left;}
+div#quickbuff div#players p {clear: both;}
+.fshLastActivity {color: #ccc; font-size: x-small;}
 
 /*
  * Table styles

--- a/calfSystem.css
+++ b/calfSystem.css
@@ -18,10 +18,25 @@
 
 .reportLink {cursor:pointer; text-decoration:underline; color:blue;}
 .fshLink {cursor:pointer; text-decoration:underline;}
-.fshRed {color:red;}
-.fshBlue {color:blue}
+
+.fshRed       {color: red;}
+.fshBlue      {color: blue;}
+.fshGreen     {color: green;}
+.fshNavy      {color: navy;}
+.fshMaroon    {color: maroon;}
+.fshWhite     {color: white;}
+
+.fshCommon    {color: white;}
+.fshRare      {color: #0099ff;}
+.fshUnique    {color: #cc33ff;}
+.fshLegendary {color: #ffff00;}
+.fshSuper     {color: #ff0000;}
+.fshCrystal   {color: #6633ff;}
+.fshEpic      {color: #00cc00;}
+
+
 .fshNoWrap {white-space: nowrap;}
-.helperQC {cursor: pointer;}
+.helperQC  {cursor: pointer;}
 
 .qbT {margin: 0px auto;}
 .qbTH {text-align: center; padding:0px 4px; color:orange;}
@@ -48,9 +63,7 @@ img.center {
   margin-right: auto;
 }
 
-td.lvlHighlight {
-  background-color:#4671C8;
-}
+td.lvlHighlight {background-color:#4671C8;}
 
 span#fshRefresh {
   text-decoration: underline;

--- a/calfSystem.css
+++ b/calfSystem.css
@@ -26,6 +26,14 @@
 .qbT {margin: 0px auto;}
 .qbTH {text-align: center; padding:0px 4px; color:orange;}
 .qbTD {text-align: center; padding:0px 4px;}
+div#quickbuff div#players h1 {float: left;}
+div#quickbuff div#players p {clear: both;}
+.fshLastActivity {color: #ccc; font-size: x-small;}
+
+div#quickbuff div.buff-block p label.fshDim span {
+  color: #999;
+}
+
 
 table.relicT {font-size:small;}
 table.relicT tr.hidden {display:none; visibility:hidden;}
@@ -55,10 +63,6 @@ div#fshCompConf {
   text-align: right;
   padding-right: 38px;
 }
-
-div#quickbuff div#players h1 {float: left;}
-div#quickbuff div#players p {clear: both;}
-.fshLastActivity {color: #ccc; font-size: x-small;}
 
 /*
  * Table styles

--- a/calfSystem.js
+++ b/calfSystem.js
@@ -432,7 +432,22 @@ window.System = {
 				return sParameterName[1] === undefined ? true : sParameterName[1];
 			}
 		}
-	}
+	},
+
+	formatLastActivity: function(last_login) {
+		var d, h, m, s;
+		//~ s = Math.floor(ms / 1000);
+		s = Math.abs(Math.floor(Date.now() / 1000 - last_login));
+		m = Math.floor(s / 60);
+		s = s % 60;
+		h = Math.floor(m / 60);
+		m = m % 60;
+		d = Math.floor(h / 24);
+		h = h % 24;
+		//~ return { d: d, h: h, m: m, s: s };
+		return 'Last Activity: ' + d + ' days, ' + h + ' hours, ' + m +
+			' minutes, ' + s + ' secs';
+	},
 };
 System.init();
 
@@ -901,6 +916,7 @@ window.Data = {
 
 		enableTempleAlert: false,
 		enableUpgradeAlert: false,
+		enableComposingAlert: false,
 		autoFillMinBidPrice: true,
 		showPvPSummaryInLog: false,
 		enableQuickDrink: false,
@@ -968,6 +984,9 @@ window.Data = {
 		lastMembrListCheck: 0,
 		disableItemColoring: false,
 		showQuickSendLinks: false,
+		needToCompose: false,
+		lastComposeCheck: 0,
+		lastOnlineCheck: 0,
 
 /* jshint -W110 */ // Mixed double and single quotes. (W110)
 
@@ -1127,6 +1146,7 @@ window.Data = {
 		'maxGroupSizeToJoin',
 		'enableTempleAlert',
 		'enableUpgradeAlert',
+		'enableComposingAlert',
 		'autoFillMinBidPrice',
 		'showPvPSummaryInLog',
 		'enableQuickDrink',
@@ -1386,19 +1406,24 @@ window.Layout = {
 		'<th class="qbTH">Extend</span></th>' +
 		'<th class="qbTH">Reinforce</span></th>' +
 		'</tr></thead><tbody><tr>' +
-		'<td id="fshSus" class="qbTD"></td>' +
-		'<td id="fshFur" class="qbTD"></td>' +
-		'<td id="fshGB"  class="qbTD"></td>' +
-		'<td id="fshBM"  class="qbTD"></td>' +
-		'<td id="fshExt" class="qbTD"></td>' +
-		'<td id="fshRI"  class="qbTD"></td>' +
+		'<td id="fshSus" class="qbTD">&nbsp;</td>' +
+		'<td id="fshFur" class="qbTD">&nbsp;</td>' +
+		'<td id="fshGB"  class="qbTD">&nbsp;</td>' +
+		'<td id="fshBM"  class="qbTD">&nbsp;</td>' +
+		'<td id="fshExt" class="qbTD">&nbsp;</td>' +
+		'<td id="fshRI"  class="qbTD">&nbsp;</td>' +
 		'</tr></tbody></table>' +
 		'</div>',
 
 	goldUpgradeMsg:
 		'<li class="notification"><a href="index.php?cmd=points&type=1"><span' +
 		' class="notification-icon"></span><p class="notification-content">Up' +
-		'grade stamina with gold.</p></a></li>'
+		'grade stamina with gold</p></a></li>',
+
+	composeMsg:
+		'<li class="notification"><a href="index.php?cmd=composing"><span' +
+		' class="notification-icon"></span><p class="notification-content">Co' +
+		'mposing to do</p></a></li>'
 
 };
 })();

--- a/calfSystem.js
+++ b/calfSystem.js
@@ -1140,14 +1140,15 @@ window.Data = {
 		'disableComposingPrompts'
 	],
 
-	craftAbbr: {
-		Perfect    : 'Perf',
-		Excellent  : 'Exc',
-		'Very Good': 'VG',
-		Good       : 'Good',
-		Average    : 'Ave',
-		Poor       : 'Poor',
-		'Very Poor': 'VPr'
+	craft: {
+		Perfect    : {abbr: 'Perf', colour: '#00b600'},
+		Excellent  : {abbr: 'Exc',  colour: '#f6ed00'},
+		'Very Good': {abbr: 'VG',   colour: '#f67a00'},
+		Good       : {abbr: 'Good', colour: '#f65d00'},
+		Average    : {abbr: 'Ave',  colour: '#f64500'},
+		Poor       : {abbr: 'Poor', colour: '#f61d00'},
+		'Very Poor': {abbr: 'VPr',  colour: '#b21500'},
+		Uncrafted  : {abbr: 'Unc',  colour: '#666666'}
 	},
 
 	itemType: {
@@ -1168,7 +1169,17 @@ window.Data = {
 		14: 'Container',
 		15: 'Composed Potion',
 		16: 'Frag Stash'
-	}
+	},
+
+	rarityColour: [
+		'#FFFFFF', // Common
+		'#00A0A0', // Rare '#40FFFF'
+		'#FF40FF', // Unique
+		'#FFFF40', // Legendary '#F6ED00'
+		'#FF0000', // Super Elite
+		'#b677f5', // Crystalline
+		'#008000'  // Epic '#00FF00'
+	]
 
 };
 

--- a/calfSystem.js
+++ b/calfSystem.js
@@ -1171,35 +1171,29 @@ window.Data = {
 		Uncrafted  : {abbr: 'Unc',  colour: '#666666'}
 	},
 
-	itemType: {
-		0 : 'Helmet',
-		1 : 'Armour',
-		2 : 'Gloves',
-		3 : 'Boots',
-		4 : 'Weapon',
-		5 : 'Shield',
-		6 : 'Ring',
-		7 : 'Amulet',
-		8 : 'Rune',
-		9 : 'Quest Item',
-		10: 'Potion',
-		11: 'Component',
-		12: 'Resource',
-		13: 'Recipe',
-		14: 'Container',
-		15: 'Composed Potion',
-		16: 'Frag Stash'
-	},
+	itemType: ['Helmet', 'Armour', 'Gloves', 'Boots', 'Weapon', 'Shield',
+		'Ring', 'Amulet', 'Rune', 'Quest Item', 'Potion', 'Component',
+		'Resource', 'Recipe', 'Container', 'Composed Potion', 'Frag Stash'],
 
 	rarityColour: [
-		'#FFFFFF', // Common
-		'#00A0A0', // Rare '#40FFFF'
-		'#FF40FF', // Unique
-		'#FFFF40', // Legendary '#F6ED00'
-		'#FF0000', // Super Elite
-		'#b677f5', // Crystalline
-		'#008000'  // Epic '#00FF00'
-	]
+		'#ffffff', // Common
+		'#0099ff', // Rare '#40FFFF'
+		'#ff33ff', // Unique
+		'#ffff66', // Legendary '#F6ED00'
+		'#ff3333', // Super Elite
+		'#6633ff', // Crystalline
+		'#009900'  // Epic '#00FF00'
+	],
+
+	rarity: {
+		'0': {colour: '#ffffff', class: 'fshCommon'},
+		'1': {colour: '#0099ff', class: 'fshRare'},
+		'2': {colour: '#cc00ff', class: 'fshUnique'},
+		'3': {colour: '#ffff33', class: 'fshLegendary'},
+		'4': {colour: '#cc0033', class: 'fshSuper'},
+		'5': {colour: '#6633ff', class: 'fshCrystal'},
+		'6': {colour: '#009900', class: 'fshEpic'}
+	}
 
 };
 
@@ -1379,17 +1373,17 @@ window.Layout = {
 
 	advisorColumns: [
 		{title: 'Member'},
-		{title: 'Lvl', class: 'dt-center'},
-		{title: 'Rank', class: 'dt-center dt-nowrap'},
+		{title: 'Lvl',                class: 'dt-center'},
+		{title: 'Rank',               class: 'dt-center dt-nowrap'},
 		{title: 'Gold From Deposits', class: 'dt-center'},
-		{title: 'Gold From Tax', class: 'dt-center'},
-		{title: 'Gold Total', class: 'dt-center'},
-		{title: 'FSP', class: 'dt-center'},
-		{title: 'Skill Cast', class: 'dt-center'},
-		{title: 'Group Create', class: 'dt-center'},
-		{title: 'Group Join', class: 'dt-center'},
-		{title: 'Relic', class: 'dt-center'},
-		{title: 'XP Contrib', class: 'dt-center'}
+		{title: 'Gold From Tax',      class: 'dt-center'},
+		{title: 'Gold Total',         class: 'dt-center'},
+		{title: 'FSP',                class: 'dt-center'},
+		{title: 'Skill Cast',         class: 'dt-center'},
+		{title: 'Group Create',       class: 'dt-center'},
+		{title: 'Group Join',         class: 'dt-center'},
+		{title: 'Relic',              class: 'dt-center'},
+		{title: 'XP Contrib',         class: 'dt-center'}
 	],
 
 	places:['first', 'second', 'third', 'fourth', 'fifth', 'sixth', 'seventh',

--- a/calfSystem.js
+++ b/calfSystem.js
@@ -1171,7 +1171,7 @@ window.Data = {
 		Uncrafted  : {abbr: 'Unc',  colour: '#666666'}
 	},
 
-	itemType: ['Helmet', 'Armour', 'Gloves', 'Boots', 'Weapon', 'Shield',
+	itemType: ['Helmet', 'Armor', 'Gloves', 'Boots', 'Weapon', 'Shield',
 		'Ring', 'Amulet', 'Rune', 'Quest Item', 'Potion', 'Component',
 		'Resource', 'Recipe', 'Container', 'Composed Potion', 'Frag Stash'],
 
@@ -1185,15 +1185,15 @@ window.Data = {
 		'#009900'  // Epic '#00FF00'
 	],
 
-	rarity: {
-		'0': {colour: '#ffffff', class: 'fshCommon'},
-		'1': {colour: '#0099ff', class: 'fshRare'},
-		'2': {colour: '#cc00ff', class: 'fshUnique'},
-		'3': {colour: '#ffff33', class: 'fshLegendary'},
-		'4': {colour: '#cc0033', class: 'fshSuper'},
-		'5': {colour: '#6633ff', class: 'fshCrystal'},
-		'6': {colour: '#009900', class: 'fshEpic'}
-	}
+	rarity: [
+		{colour: '#ffffff', class: 'fshCommon'},
+		{colour: '#0099ff', class: 'fshRare'},
+		{colour: '#cc00ff', class: 'fshUnique'},
+		{colour: '#ffff33', class: 'fshLegendary'},
+		{colour: '#cc0033', class: 'fshSuper'},
+		{colour: '#6633ff', class: 'fshCrystal'},
+		{colour: '#009900', class: 'fshEpic'}
+	]
 
 };
 
@@ -1313,7 +1313,7 @@ window.Layout = {
 	playerId: function() {
 		var playerIdRE = /fallensword.com\/\?ref=(\d+)/;
 		var thePlayerId=parseInt(document.body.innerHTML.match(playerIdRE)[1],10);
-		GM_setValue('playerID',thePlayerId);
+		System.setValue('playerID',thePlayerId);
 		return thePlayerId;
 	},
 

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -530,7 +530,7 @@ var Helper = {
 			});
 		}
 
-		//This must be at the end in order not to screw up other System.findNode calls (Issue 351)
+		// This must be at the end in order not to screw up other System.findNode calls (Issue 351)
 		if (System.getValue('huntingMode') === false) {
 			Helper.injectQuickLinks();
 		}
@@ -625,7 +625,7 @@ var Helper = {
 			for (var i=2;i<memList.rows.length;i += 1) {
 				// var iplus1 = i+1;
 				if (memList.rows[i].cells[1]) {
-					//Firefox reads it as </td> and chrome reads it as \&lt;\/td\&gt;
+					// Firefox reads it as </td> and chrome reads it as \&lt;\/td\&gt;
 					var vlevel = /VL:.+?(\d+)/.exec(memList.rows[i].cells[1].innerHTML)[1];
 					// var level = memList.rows[i].cells[2].innerHTML;
 					var aRow = memList.rows[i];
@@ -7012,45 +7012,42 @@ var Helper = {
 	doGroupRow: function(e, m) {
 		var creator = $('b', e).text();
 		var td = $('td', e).first();
+		var inject = '';
 		if (m[creator]) {
-			td.html(Helper.onlineDot(Math.floor((Math.floor(Date.now() /
+			inject += Helper.onlineDot(Math.floor((Math.floor(Date.now() /
 				1000) - m[creator].last_login) / 60)) + '&nbsp;<a href="' +
 				System.server + 'index.php?cmd=profile&player_id=' +
 				m[creator].id + '">' + td.html() + '</a>' + ' [' +
-				m[creator].level + ']');
+				m[creator].level + ']';
 		}
-
 		var td2 = $('td', e).eq(1);
 		var theList = td2.html();
 		var listArr = theList.split(', ');
-
 		if (listArr.length > 1) {
 			listArr.sort(function(a, b) {
 				return (m[b] ? m[b].level : 0) - (m[a] ? m[a].level : 0);
 			});
 		}
-
+		var countMembers = 0;
 		var buffList = [];
 		listArr.forEach(function(v, i, a) {
 			if (v.indexOf('<font') !== -1) {return;}
+			countMembers += 1;
 			buffList[Math.floor(i / 16)] = buffList[Math.floor(i / 16)] || [];
 			buffList[Math.floor(i / 16)].push(v);
 			if (!m[v]) {return;}
 			a[i] = ' <a href="index.php?cmd=profile&player_id=' +
 				m[v].id + '">' + v + '</a>';
 		});
-
 		buffList.forEach(function(v, i) {
-			td.append('<br><a href=\'' + Layout.buffAllHref(v) +
+			inject += '<br><a href=\'' + Layout.buffAllHref(v) +
 				'\'><span style="color:blue; font-size:x-small;" title="Quick ' +
 				'buff functionality from HCS only does 16">Buff ' +
-				Layout.places[i] + ' 16</span></a>'
-			);
+				Layout.places[i] + ' 16</span></a>';
 		});
-
-		var formList = listArr.join(', ');
-		td2.html('<span>' + formList + '</span>');
-
+		td.html(inject + '<br><span style="font-size:x-small;">Members: ' +
+			countMembers + '</span>');
+		td2.html('<span>' + listArr.join(', ') + '</span>');
 		Helper.groupLocalTime($('td', e).eq(2));
 	},
 

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -9,8 +9,8 @@
 // @include        http://local.huntedcow.com/fallensword/*
 // @exclude        http://forum.fallensword.com/*
 // @exclude        http://wiki.fallensword.com/*
-// @version        1507b3
-// @downloadURL    https://fallenswordhelper.github.io/fallenswordhelper/Releases/Beta/fallenswordhelper.user.js
+// @version        1507
+// @downloadURL    https://fallenswordhelper.github.io/fallenswordhelper/Releases/Current/fallenswordhelper.user.js
 // @grant          none
 // ==/UserScript==
 

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -21,13 +21,8 @@ var fshMain = function() {
 
 'use strict';
 
-//~ var isBeta ='0';
-//~ var isNewUI = '0';
-
 var Helper = {
 	prepareEnv: function() {
-		// TODO This can be moved I think
-		// It was back when some people used an image pack
 		if (System.getValue('gameHelpLink')) {
 			var gameHelpNode = $('div.minibox h3:contains("Game Help")');
 			$(gameHelpNode).each(function() {
@@ -39,7 +34,7 @@ var Helper = {
 
 		if (System.getValue('huntingMode')) {
 			Helper.replaceKeyHandler();
-			Helper.fixOnlineGuildBuffLinks(); // Do we really need to do this in hunt mode?
+			// Helper.fixOnlineGuildBuffLinks();
 		} else {
 			//move boxes in opposite order that you want them to appear.
 			if (System.getValue('moveGuildList')) {
@@ -52,9 +47,7 @@ var Helper = {
 				Layout.moveRHSBoxToLHS('minibox-fsbox');
 			}
 
-			Helper.prepareAllyEnemyList(); // TODO need to do something cleverer
-			//~ Helper.prepareGuildList();
-			//~ Helper.retrieveGuildData(); // TODO need to do something cleverer
+			Helper.prepareAllyEnemyList();
 			Helper.prepareBountyData();
 			Helper.injectStaminaCalculator();
 			Helper.injectLevelupCalculator();
@@ -66,10 +59,11 @@ var Helper = {
 			Helper.addOnlineAlliesWidgets();
 			Helper.injectJoinAllLink();
 			Helper.changeGuildLogHREF();
-			//~ Helper.injectAHsearch();
-			Helper.injectHomePageTwoLink(); // TODO need to do something cleverer
-			Helper.injectTempleAlert();
-			Helper.injectUpgradeAlert();
+			Helper.injectHomePageTwoLink();
+			if (System.getValue('enableTempleAlert')) {
+				Helper.injectTempleAlert();}
+			if (System.getValue('enableUpgradeAlert')) {
+				Helper.injectUpgradeAlert();}
 			Helper.injectQuickMsgDialogJQ();
 		}
 
@@ -167,7 +161,7 @@ var Helper = {
 		case 'arena':
 			switch (subPageId) {
 			case '-':
-				//Helper.injectArena();
+				// Helper.injectArena();
 				break;
 			case 'completed':
 				Helper.storeCompletedArenas();
@@ -176,10 +170,10 @@ var Helper = {
 				Helper.storeArenaMoves();
 				break;
 			case 'results':
-				//Helper.injectTournament();
+				// Helper.injectTournament();
 				break;
 			case 'dojoin':
-				//Helper.injectTournament();
+				// Helper.injectTournament();
 				break;
 			case 'setup':
 				Helper.injectArenaSetupMove();
@@ -261,7 +255,6 @@ var Helper = {
 				}
 				break;
 			case 'manage':
-				//~ Helper.parseGuildForWorld();
 				Helper.injectGuild();
 				break;
 			case 'advisor':
@@ -364,14 +357,8 @@ var Helper = {
 			case 'bufflogcontent':
 				Helper.injectBuffLog();
 				break;
-			case 'guildlog':
-				//~ Helper.injectGuildLogSummary();
-				break;
 			case 'newguildlog':
 				Helper.injectNewGuildLog();
-				break;
-			case 'checkwear':
-				//~ Helper.injectCheckWearingItem();
 				break;
 			case 'findbuffs':
 				Helper.injectFindBuffs();
@@ -395,16 +382,12 @@ var Helper = {
 				switch (typePageId) {
 				case '-':
 					Helper.storePlayerUpgrades();
-					//Helper.injectPoints();
 					break;
 				case '0':
 					Helper.storePlayerUpgrades();
-					//Helper.injectPoints();
 					break;
 				case '1':
 					Helper.parseGoldUpgrades();
-					//Helper.storePlayerUpgrades();
-					//Helper.injectPoints();
 					break;
 				default:
 					break;
@@ -448,7 +431,7 @@ var Helper = {
 			default:
 				break;
 			}
-			//Helper.injectInvent();
+			// Helper.injectInvent();
 			break;
 		case 'tempinv':
 			Helper.injectMailbox();
@@ -500,10 +483,6 @@ var Helper = {
 			if (isBuffResult) {
 				Helper.updateBuffLog();
 			}
-			//~ var isAuctionPage = System.findNode('//img[contains(@title,"Auction House")]');
-			//~ if (isAuctionPage) {
-				//~ Helper.injectAuctionHouse();
-			//~ }
 			var isShopPage =  $('#shop-info').length > 0;//System.findNode('//td[contains(.,"then click to purchase for the price listed below the item.")]');
 			if (isShopPage) {
 				Helper.injectShop();
@@ -518,14 +497,14 @@ var Helper = {
 			if (isAdvisorPageClue1 && isAdvisorPageClue2) {
 				Helper.injectAdvisor(subPage2Id);
 			}
-			//~ var isArenaTournamentPage = System.findNode('//b[contains(.,"Tournament #")]');
-			//~ if (isArenaTournamentPage) {
-				//~ Helper.injectTournament();
-			//~ }
+			// var isArenaTournamentPage = System.findNode('//b[contains(.,"Tournament #")]');
+			// if (isArenaTournamentPage) {
+				// Helper.injectTournament();
+			// }
 			if (System.findNode('//a[.="Back to Scavenging"]')) {
 				Helper.injectScavenging();
 			}
-			if($('img[title="Inventing"]').length > 0){
+			if ($('img[title="Inventing"]').length > 0) {
 				Helper.injectInvent();
 			}
 			break;
@@ -644,12 +623,11 @@ var Helper = {
 			var characterVirtualLevel = System.getValue('characterVirtualLevel');
 			if (characterVirtualLevel) {levelToTest = characterVirtualLevel;}
 			for (var i=2;i<memList.rows.length;i += 1) {
-				//~ var iplus1 = i+1;
+				// var iplus1 = i+1;
 				if (memList.rows[i].cells[1]) {
 					//Firefox reads it as </td> and chrome reads it as \&lt;\/td\&gt;
-					// TODO Test
 					var vlevel = /VL:.+?(\d+)/.exec(memList.rows[i].cells[1].innerHTML)[1];
-					//~ var level = memList.rows[i].cells[2].innerHTML;
+					// var level = memList.rows[i].cells[2].innerHTML;
 					var aRow = memList.rows[i];
 					if (highlightPlayersNearMyLvl && Math.abs(vlevel - levelToTest) <= (levelToTest <= 205 ? 5 : 10)) {
 						aRow.style.backgroundColor = '#4671C8'; //blue
@@ -884,7 +862,7 @@ var Helper = {
 	},
 
 	recallGuildStoreItemReturnMessage: function(responseText, callback) {
-		//~ var itemID = callback.item;
+		// var itemID = callback.item;
 		var target = callback.target;
 		var info = Layout.infoBox(responseText);
 		var itemCellElement = target.parentNode; //System.findNode('//td[@title="' + itemID + '"]');
@@ -911,7 +889,7 @@ var Helper = {
 		var nextGain = $(staminaMouseover).find('dt.stat-stamina-nextGain:first').next().text().replace(/,/g,'');
 		var nextGainRE = /([,0-9]+)m ([,0-9]+)s/;
 		var nextGainMinutes = System.intValue(nextGainRE.exec(nextGain)[1]);
-		//~ var nextGainSeconds = System.intValue(nextGainRE.exec(nextGain)[2]);
+		// var nextGainSeconds = System.intValue(nextGainRE.exec(nextGain)[2]);
 		var nextGainHours = nextGainMinutes/60;
 		//get the max hours to still be inside stamina maximum
 		var hoursToMaxStamina = Math.floor((maxStamina - curStamina)/gainPerHour);
@@ -919,7 +897,7 @@ var Helper = {
 		var now = Date.now();
 		var nextHuntMilliseconds = now + millisecondsToMaxStamina;
 		var d = new Date(nextHuntMilliseconds);
-		//~ var nextHuntTimeText = d.toFormatString('HH:mm ddd dd/MMM/yyyy');
+		// var nextHuntTimeText = d.toFormatString('HH:mm ddd dd/MMM/yyyy');
 		var nextHuntTimeText = System.formatShortDate(d);
 		$(staminaMouseover).append('<dt class="stat-stamina-nextHuntTime">Max Stam At</dt><dd>' + nextHuntTimeText + '</dd>');
 	},
@@ -936,7 +914,7 @@ var Helper = {
 		var millisecsToNextGain = (hoursToNextLevel*60*60+nextGainMin*60+nextGainSec)*1000;
 		nextGainTime  = new Date(Date.now() + millisecsToNextGain);
 		$('dl[id="statbar-level-tooltip-general"]').append('<dt class="stat-xp-nextLevel">Next Level At</dt><dd>'+
-				//~ nextGainTime.toFormatString('HH:mm ddd dd/MMM/yyyy')+'</dd>');
+				// nextGainTime.toFormatString('HH:mm ddd dd/MMM/yyyy')+'</dd>');
 				System.formatShortDate(nextGainTime)+'</dd>');
 	},
 
@@ -1046,11 +1024,9 @@ var Helper = {
 
 		var injectHere = $('td:contains("Defended"):last');
 		if (injectHere.length === 0) {return;}
-		//~ if (injectHere.length > 0) {
 		var defendingGuildMiniSRC = $('img[src*="_mini.jpg"]').attr('src');
 		var defendingGuildID = /guilds\/(\d+)_mini.jpg/
 			.exec(defendingGuildMiniSRC)[1];
-		//~ var myGuildID = System.getValue('guildID');
 		if (defendingGuildID === Layout.guildId().toString()) {
 			var listOfDefenders = injectHere.next().text().split(',');
 			// quick buff only supports 16
@@ -1061,7 +1037,6 @@ var Helper = {
 					shortList.push(listOfDefenders[i]);
 					if ((i + 1) % 16 === 0 && i !== 0 ||
 						i === listOfDefenders.length - 1) {
-						//~ modifierWord = Helper.getGroupBuffModifierWord(i);
 						modifierWord = Layout.places[Math.floor(i / 16)];
 						var htmlToAppend = '<br><nobr><a href="#" id="buffAll' +
 							modifierWord + '"><span style="color:blue; font-' +
@@ -1076,7 +1051,6 @@ var Helper = {
 				}
 			}
 		}
-		//~ injectHere.html(injectHere.html() + '<input id="calculatedefenderstats" type="button" value="Fetch Stats" title="Calculate the stats of the players defending the relic." class="custombutton">');
 		injectHere.append('<input id="calculatedefenderstats" type="button" ' +
 			'value="Fetch Stats" title="Calculate the stats of the players ' +
 			'defending the relic." class="custombutton">');
@@ -1092,7 +1066,6 @@ var Helper = {
 	calculateRelicDefenderStats: function() {
 		var validMemberString;
 		var membrList = Helper.membrList;
-		//~ var i;
 		//hide the calc button
 		$('input[id="calculatedefenderstats"]').css('visibility','hidden');
 		//make the text smaller
@@ -1150,21 +1123,6 @@ var Helper = {
 		});
 		Helper.relicDefenderCount = defenders.length;
 
-		//~ var listOfDefenders = System.findNodes('//b/a[contains(@href,"index.php?cmd=profile&player_id=")]');
-		//~ var defenderCount = 0;
-		//~ var testList = '';
-		//~ for (i = 0; i < listOfDefenders.length; i += 1) {
-			//~ var hrefpointer = listOfDefenders[i].getAttribute('href');
-			//~ Helper.getRelicPlayerData(defenderCount, extraTextInsertPoint, hrefpointer);
-			//~ testList += listOfDefenders[i].innerHTML + ' ';
-			//~ if (defendingGuildID === myGuildID && !hideRelicOffline) {
-				//~ validMemberString = validMemberString.replace(listOfDefenders[i].innerHTML + ' ','');
-			//~ }
-			//~ defenderCount+= 1;
-		//~ }
-		//~ Helper.relicDefenderCount = defenderCount;
-
-		//extraTextInsertPoint.innerHTML += '<tr><td style="font-size:x-small;">' + testList + '<td><tr>';
 		var textToInsert = '<tr><td><table class="relicT">' +
 			'<tr><td colspan="2" class="headr">Defending Guild Stats</td></tr>' +
 			'<tr><td class="brn">Number of Defenders:</td>' +
@@ -1278,53 +1236,29 @@ var Helper = {
 		extraTextInsertPoint.innerHTML += textToInsert;
 	},
 
-	getRelicGuildData: function(extraTextInsertPoint,hrefpointer) {
-		//~ System.xmlhttp(hrefpointer, Helper.parseRelicGuildData, {'extraTextInsertPoint':extraTextInsertPoint});
+	getRelicGuildData: function(extraTextInsertPoint, hrefpointer) {
 		System.xmlhttp(hrefpointer, Helper.parseRelicGuildData);
 	},
 
 	parseRelicGuildData: function(responseText) {
-		//~ var extraTextInsertPoint = callback.extraTextInsertPoint;
 		var doc = System.createDocument(responseText);
-
 		var relicCount = $('div#pCC table table table img[data-tipped*="' +
 			'Relic Bonuses"]', doc).length;
-//console.log('relicCount', relicCount);
-		//~ var allItems = doc.getElementsByTagName('IMG');
-		//~ var relicCount = 0;
-		//~ for (var i=0;i<allItems.length-1;i += 1) {
-			//~ var anItem=allItems[i];
-			//~ var mouseoverText = $(anItem).data('tipped');
-			//~ if (mouseoverText && mouseoverText.search('Relic Bonuses') !== -1){
-				//~ relicCount+= 1;
-			//~ }
-		//~ }
 		var relicCountElement = $('td[title="relicCount"]');
 		relicCountElement.html(relicCount);
 		var relicProcessedElement = $('td[title="relicProcessed"]');
 		relicProcessedElement.html(1);
-		//if all defenders processed and relic processed, then finalize totals
-		//~ var defendersProcessed = $('td[title="defendersProcessed"]');
-		//~ var defendersProcessedNumber = System.intValue(defendersProcessed.html());
-
-		//~ if (Helper.relicDefenderCount === defendersProcessedNumber + 1) {
-			//~ Helper.processRelicStats();
-		//~ }
 		Helper.syncRelicData();
 	},
 
 	getRelicPlayerData: function(defenderCount, hrefpointer, pl) {
-
 		if (defenderCount === 0) {
-
 			System.xmlhttp(
 				hrefpointer,
 				Helper.parseRelicPlayerData,
 				{'defenderCount': defenderCount}
 			);
-
 		} else {
-
 			$.ajax({
 				cache: false,
 				dataType: 'json',
@@ -1335,12 +1269,9 @@ var Helper = {
 					'player_username': pl
 				},
 				success: function(data) {
-					//~ console.log('13106 textStatus1', textStatus);
-					//~ console.log('13107 data', data);
 					Helper.parseRelicPlayerData(data, {'defenderCount': defenderCount});
 				}
 			});
-
 		}
 	},
 
@@ -1405,7 +1336,6 @@ var Helper = {
 
 	leadDefender: function(player) {
 		//get lead defender (LD) buffs here for use later ... 
-		//~ var defenderMultiplier = 1;
 		var attackValue = $('td[title="LDattackValue"]');
 		var attackNumber = System.intValue(attackValue.html());
 		attackValue.html(System.addCommas(attackNumber + Math.round(player.attackValue)));
@@ -1531,19 +1461,14 @@ var Helper = {
 		processingStatus.html('Parsing attacking group stats ... ');
 		var doc = System.createDocument(responseText);
 		var theTable = $('div#pCC table table table', doc);
-		//~ Helper.relicGroupAttackValue = $(doc).find('#stat-attack').text().replace(/,/g,'')*1;
 		Helper.relicGroupAttackValue = System.intValue($('td#stat-attack',
 			theTable).text());
-		//~ Helper.relicGroupDefenseValue = $(doc).find('#stat-defense').text().replace(/,/g,'')*1;
 		Helper.relicGroupDefenseValue = System.intValue($('td#stat-defense',
 			theTable).text());
-		//~ Helper.relicGroupArmorValue = $(doc).find('#stat-armor').text().replace(/,/g,'')*1;
 		Helper.relicGroupArmorValue = System.intValue($('td#stat-armor',
 			theTable).text());
-		//~ Helper.relicGroupDamageValue = $(doc).find('#stat-damage').text().replace(/,/g,'')*1;
 		Helper.relicGroupDamageValue = System.intValue($('td#stat-damage',
 			theTable).text());
-		//~ Helper.relicGroupHPValue = $(doc).find('#stat-hp').text().replace(/,/g,'')*1;
 		Helper.relicGroupHPValue = System.intValue($('td#stat-hp',
 			theTable).text());
 		System.xmlhttp('index.php?cmd=guild&subcmd=mercs', Helper.parseRelicMercStats);
@@ -1599,64 +1524,6 @@ var Helper = {
 		processingStatus.html('Processing attacking group stats ... ');
 
 		var player = Helper.playerData(responseText);
-		//~ var doc = System.createDocument(responseText);
-		//~ var allItems = doc.getElementsByTagName('IMG');
-		//~ var constitutionLevel = 0;
-		//~ var flinchLevel = 0;
-		//~ var nightmareVisageLevel = 0;
-		//~ var fortitudeLevel = 0;
-		//~ var chiStrikeLevel = 0;
-		//~ var terrorizeLevel = 0;
-		//~ var sanctuaryLevel = 0;
-		//~ var anItem;
-		//~ for (var i=0;i<allItems.length;i += 1) {
-			//~ anItem=allItems[i];
-			//~ if (anItem.getAttribute('src').search('/skills/') !== -1) {
-				//~ var onmouseover = $(anItem).data('tipped');
-				//~ var constitutionRE = /<b>Constitution<\/b> \(Level: (\d+)\)/;
-				//~ var constitution =  constitutionRE.exec(onmouseover);
-				//~ if (constitution) {
-					//~ constitutionLevel = constitution[1];
-					//~ continue;
-				//~ }
-				//~ var flinchRE = /<b>Flinch<\/b> \(Level: (\d+)\)/;
-				//~ var flinch = flinchRE.exec(onmouseover);
-				//~ if (flinch) {
-					//~ flinchLevel = flinch[1];
-					//~ continue;
-				//~ }
-				//~ var nightmareVisageRE = /<b>Nightmare Visage<\/b> \(Level: (\d+)\)/;
-				//~ var nightmareVisage = nightmareVisageRE.exec(onmouseover);
-				//~ if (nightmareVisage) {
-					//~ nightmareVisageLevel = nightmareVisage[1];
-					//~ continue;
-				//~ }
-				//~ var fortitudeRE = /<b>Fortitude<\/b> \(Level: (\d+)\)/;
-				//~ var fortitude = fortitudeRE.exec(onmouseover);
-				//~ if (fortitude) {
-					//~ fortitudeLevel = fortitude[1];
-					//~ continue;
-				//~ }
-				//~ var chiStrikeRE = /<b>Chi Strike<\/b> \(Level: (\d+)\)/;
-				//~ var chiStrike = chiStrikeRE.exec(onmouseover);
-				//~ if (chiStrike) {
-					//~ chiStrikeLevel = chiStrike[1];
-					//~ continue;
-				//~ }
-				//~ var terrorizeRE = /<b>Terrorize<\/b> \(Level: (\d+)\)/;
-				//~ var terrorize = terrorizeRE.exec(onmouseover);
-				//~ if (terrorize) {
-					//~ terrorizeLevel = terrorize[1];
-					//~ continue;
-				//~ }
-				//~ var sanctuaryRE = /<b>Sanctuary<\/b> \(Level: (\d+)\)/;
-				//~ var sanctuary = sanctuaryRE.exec(onmouseover);
-				//~ if (sanctuary) {
-					//~ sanctuaryLevel = sanctuary[1];
-					//~ continue;
-				//~ }
-			//~ }
-		//~ }
 		var groupAttackElement = $('td[title="GroupAttack"]');
 		var groupAttackBuffedElement = $('td[title="GroupAttackBuffed"]');
 		groupAttackElement.html(System.addCommas(Helper.relicGroupAttackValue));
@@ -1901,7 +1768,6 @@ var Helper = {
 				Helper.injectAdvisorWeekly :
 				Helper.injectAdvisorNew,
 			param2: false
-			//~ callback: Helper.injectAdvisorOld(System.getUrlParameter('subcmd2'))
 		});
 	},
 
@@ -2298,7 +2164,7 @@ var Helper = {
 	},
 
 	toggleKsTracker: function() {
-		var trackKS=document.getElementById('Helper:toggleKStracker');
+		var trackKS = document.getElementById('Helper:toggleKStracker');
 		if (trackKS) {
 			trackKS.addEventListener('click', function() {
 				System.setValue('trackKillStreak',
@@ -2309,7 +2175,7 @@ var Helper = {
 	},
 
 	recastImpAndRefresh: function(responseText) {
-		var doc=System.createDocument(responseText);
+		var doc = System.createDocument(responseText);
 		if (doc) {
 			window.location=window.location;
 		}
@@ -2326,8 +2192,6 @@ var Helper = {
 	injectQuestBookFull: function() {
 
 		var lastQBPage = location.search;
-		//TODO: Make this configurable on/off
-		//TODO: upgrade normal & seasonal
 		if (lastQBPage.indexOf('&mode=0') !== -1) {
 			System.setValue('lastActiveQuestPage', lastQBPage);
 		} else if (lastQBPage.indexOf('&mode=1') !== -1) {
@@ -2927,17 +2791,13 @@ var Helper = {
 
 			var huntingMode = System.getValue('huntingMode');
 			imgSource = huntingMode === true ? Data.huntingOnImage : Data.huntingOffImage;
-			//~ altText = huntingMode === true ? 'Hunting mode is ON' : 'Hunting mode is OFF';
-			//~ mapName.innerHTML += ' <a href=# id="Helper:ToggleHuntingMode"><img title="' + altText + '" src="' + imgSource + '" border=0 width=10 height=10/></a>';
 			mapName.innerHTML += ' <a href=# id="Helper:ToggleHuntingMode">' + imgSource + '</a>';
 
 			if (System.getValue('showSpeakerOnWorld')) {
 				if (System.getValue('playNewMessageSound'))
 				{
-					//~ mapName.innerHTML += '<a href="#" id="toggleSoundLink"><img border=0 title="Turn Off Sound when you have a new log message" width=10 height=10 src="' + Data.soundMuteImage + '"/></a>';
 					mapName.innerHTML += '<a href="#" id="toggleSoundLink">' + Data.soundMuteImage + '</a>';
 				} else {
-					//~ mapName.innerHTML += '<a href="#" id="toggleSoundLink"><img border=0 title="Turn On Sound when you have a new log message" width=10 height=10 src="' + Data.soundImage + '"/></a>';
 					mapName.innerHTML += '<a href="#" id="toggleSoundLink">' + Data.soundImage + '</a>';
 				}
 				document.getElementById('toggleSoundLink').addEventListener('click', Helper.toggleSound, true);
@@ -3233,7 +3093,6 @@ var Helper = {
 		}
 		output += '</table>';
 		$(injectId).html(output);
-		//~ $('#showAhPrice').click(Helper.showAHPrice);
 	},
 
 	insertQuickExtract: function(content) {
@@ -3306,7 +3165,7 @@ var Helper = {
 		if (!window.confirm('Are you sure you want to extract all similar items?')) {return;}
 		var InventoryIDs=evt.target.getAttribute('invIDs').split(',');
 		//evt.target.parentNode.innerHTML = InventoryIDs;
-		//~ var output= '';
+		// var output= '';
 		evt.target.parentNode.innerHTML = 'extracting all ' + InventoryIDs.length + ' resources';
 		for (var i=0; i<InventoryIDs.length; i += 1){
 			//output+='index.php?cmd=profile&subcmd=useitem&inventory_id='+InventoryIDs[i]+'<br>';
@@ -3331,7 +3190,7 @@ var Helper = {
 			var theMap = System.getValueJSON('map');
 			var realm = System.findNode('//h3[@id="world-realm-name"]');
 			if ($('h3#world-realm-name').data('realm')) {
-				//~ var realmId = $('h3#world-realm-name').data('realm').id.trim();
+				// var realmId = $('h3#world-realm-name').data('realm').id.trim();
 				levelName = $('h3#world-realm-name').data('realm').name.trim();
 			}
 			if (!levelName) {levelName=realm.innerHTML;}
@@ -3471,7 +3330,7 @@ var Helper = {
 		var hitpoints = parseInt(hitpointsNode.textContent.replace(/,/g,''),10);
 		var armorNumber = parseInt(armorNode.textContent.replace(/,/g,''),10);
 		var combatEvaluatorBias = System.getValue('combatEvaluatorBias');
-		//~ var attackVariable = 1.1053
+		// var attackVariable = 1.1053
 		var generalVariable = 1.1053;
 		var hpVariable = 1.1;
 		if (combatEvaluatorBias === 1) {
@@ -3664,11 +3523,6 @@ var Helper = {
 		var content = document.getElementById('Helper.entityTableOutput');
 		var i;
 		if (!Helper.entityLogTable || !content) {return;}
-		//~ System.addStyle(
-			//~ '.HelperMonsterLogRow1 {background-color:#e7c473;font-size:small}\n' +
-			//~ '.HelperMonsterLogRow1:hover {background-color:white}\n' +
-			//~ '.HelperMonsterLogRow2 {background-color:#e2b960;font-size:small}\n' +
-			//~ '.HelperMonsterLogRow2:hover {background-color:white}');
 
 		var result = '<table cellspacing="0" cellpadding="0" border="0" width="100%"><tr style="background-color:#110011; color:white;">'+
 			'<td width="90%" nobr align=center><b>&nbsp;Entity Information</b></td>'+
@@ -3913,14 +3767,12 @@ var Helper = {
 	},
 
 	replaceKeyHandler: function() {
-		//~ setTimeout(function() { // FF3.6 was not working without the timeout in place
-			if ($('#worldPage').length === 0) { // not new map
-				//clear out the HCS keybinds so only helper ones fire
-				$.each($(document).controls('option').keys, function(index) { 
-					$(document).controls('option').keys[index] = [];
-				});
-			}
-		//~ }, 0);
+		if ($('#worldPage').length === 0) { // not new map
+			//clear out the HCS keybinds so only helper ones fire
+			$.each($(document).controls('option').keys, function(index) { 
+				$(document).controls('option').keys[index] = [];
+			});
+		}
 		unsafeWindow.document.onkeypress = null;
 		unsafeWindow.document.combatKeyHandler = null;
 		unsafeWindow.document.realmKeyHandler = null;
@@ -4156,11 +4008,8 @@ var Helper = {
 		if (!chatTable) {chatTable = System.findNode('//table[tbody/tr/td/span[contains(.,"Currently showing:")]]');} //personal log
 		if (!chatTable) {return;}
 
-		// fix for Chrome table width problem
-		//~ if (logScreen === 'Chat' && navigator.userAgent.indexOf('Firefox') === -1) {
 		chatTable.style.tableLayout = 'fixed';
 		chatTable.style.wordWrap = 'break-word';
-		//~ }
 
 		var localDateMilli = Date.now();
 		var gmtOffsetMinutes = (new Date()).getTimezoneOffset();
@@ -4194,8 +4043,6 @@ var Helper = {
 				}
 			}
 		}
-		//~ var now=(new Date()).getTime();
-		//~ System.setValue(lastCheckScreen, now.toString());
 		System.setValue(lastCheckScreen, Date.now());
 	},
 
@@ -4212,12 +4059,7 @@ var Helper = {
 		var logTable = System.findNode('//table[tbody/tr/td/span[contains' +
 			'(.,"Currently showing:")]]');
 		if (!logTable) {return;}
-		//~ var memberList = System.getValueJSON('memberlist');
 		var memberNameString = ' ' + Object.keys(Helper.membrList).join(' ') + ' ';
-		//~ if (memberList) {
-			//~ memberNameString += memberList.members
-				//~ .map(function(o) {return o.name;}).join(' ') + ' ';
-		//~ }
 		var listOfEnemies = System.getValue('listOfEnemies');
 		if (!listOfEnemies) {listOfEnemies = '';}
 		var listOfAllies = System.getValue('listOfAllies');
@@ -4238,11 +4080,7 @@ var Helper = {
 			if (!aRow.cells[0].innerHTML) {continue;}
 			var firstCell = aRow.cells[0];
 			//Valid Types: General, Chat, Guild
-			// if (navigator.userAgent.indexOf('Firefox')>0) {
-				// messageType = firstCell.firstChild.getAttribute('title');
-			// } else { //chrome
 			messageType = firstCell.firstChild.getAttribute('oldtitle');
-			// }
 			if (!messageType) {return;}
 			var colorPlayerName = false;
 			var isGuildMate = false;
@@ -4276,9 +4114,6 @@ var Helper = {
 			if (messageType === 'Chat') {
 				Helper.doChat(aRow, isGuildMate, playerName, addAttackLinkToLog);
 			}
-			//~ if (aRow.cells[2].innerHTML.search('You have just been outbid at the auction house') !== -1) {
-				//~ aRow.cells[2].innerHTML += '. Go to <a href="/index.php?cmd=auctionhouse&type=-50">My Bids</a>.';
-			//~ }
 			if (messageType === 'Notification') {
 				if (aRow.cells[2].firstChild.nextSibling && aRow.cells[2].firstChild.nextSibling.nodeName === 'A') {
 					if (aRow.cells[2].firstChild.nextSibling.getAttribute('href').search('player_id') !== -1) {
@@ -4320,12 +4155,10 @@ var Helper = {
 					{'target': combatSummarySpan});
 			}
 		}
-		//GM_wait(function() { // just want to be on the safe side
 		$('.a-reply').click(function(evt) {
 			Helper.openQuickMsgDialog(evt.target.getAttribute('target_player'),
 				'', evt.target.getAttribute('replyTo'));
 		});
-		//});
 	},
 
 	doChat: function(aRow, isGuildMate, playerName, addAttackLinkToLog) {
@@ -4346,7 +4179,7 @@ var Helper = {
 
 		var messageHTML = aRow.cells[2].innerHTML;
 		var firstPart = messageHTML.substring(0, messageHTML.indexOf('<small>') + 7);
-		//~ var secondPart = messageHTML.substring(messageHTML.indexOf('<small>') + 7, messageHTML.indexOf('>Reply</a>') + 10);
+		// var secondPart = messageHTML.substring(messageHTML.indexOf('<small>') + 7, messageHTML.indexOf('>Reply</a>') + 10);
 		var thirdPart = messageHTML.substring(messageHTML.indexOf('>Reply</a>') + 10, messageHTML.indexOf('>Buff</a>') + 9);
 		var targetPlayerID = /quickBuff\((\d+)\)/.exec(thirdPart)[1];
 		thirdPart = ' | <a ' + Layout.quickBuffHref(targetPlayerID) + '>Buff</a></span>';
@@ -4425,7 +4258,7 @@ var Helper = {
 	},
 
 	retrievePvPCombatSummary: function(responseText, callback) {
-		//~ var doc = System.createDocument(responseText);
+		// var doc = System.createDocument(responseText);
 		var winner = System.getIntFromRegExp(responseText, /var\s+winner=(-?[0-9]+);/i);
 		var xpGain = System.getIntFromRegExp(responseText, /var\s+xpGain=(-?[0-9]+);/i);
 		var goldGain = System.getIntFromRegExp(responseText, /var\s+goldGain=(-?[0-9]+);/i);
@@ -4544,9 +4377,6 @@ var Helper = {
 	},
 
 	generateManageTable: function() {
-		//~ System.addStyle('.HelperTextLink {color:blue;font-size:x-small;cursor:pointer;}\n' +
-			//~ '.HelperTextLink:hover {text-decoration:underline;}\n');
-		//~ var i, j, result='<table cellspacing=2 cellpadding=2 width=100%><tr bgcolor=#CD9E4B>';
 		var i, j, result='<table cellspacing=2 cellpadding=2 style="table-layout: fixed; word-wrap: break-word;" width=100%><tr bgcolor=#CD9E4B>';
 		var isArrayOnly= Helper.param.fields.length === 0;
 		for (i=0;i<Helper.param.headers.length;i += 1) {
@@ -4715,8 +4545,6 @@ var Helper = {
 					localforage.setItem('membrList', membrList,
 						function(err, membrList) {
 							if (err) {console.log('localforage error', err);}
-							// Assign as global because in future we may have
-							// multiple concurrent ajax calls before the callback
 							Helper.membrList = membrList;
 							fn(membrList);
 						}
@@ -4910,7 +4738,7 @@ var Helper = {
 	},
 
 	changeCombatSet: function(responseText, itemIndex) {
-		var doc=System.createDocument(responseText);
+		var doc = System.createDocument(responseText);
 
 		var cbsSelect = System.findNode('//select[@name="combatSetId"]', doc);
 
@@ -5604,7 +5432,7 @@ var Helper = {
 		if (buffs) {
 			for (var i=0;i<buffs.length;i += 1) {
 				var fullName=buffs[i].replace(/(`~)|(~`)|(\{b\})|(\{\/b\})/g,'');
-				//~ var buffName = Helper.removeHTML(fullName);
+				// var buffName = Helper.removeHTML(fullName);
 				var cbString =
 					'<span id="Helper:buff'+i+'" style="color:blue;cursor:pointer">'+
 					fullName+'</span>';
@@ -5686,7 +5514,6 @@ var Helper = {
 					break;
 			}
 			if (changeAppearance) {
-				//~ var settingsAry = Data.guildRelationshipMessages();
 				var settingsAry = Data.guildMessages;
 				warning.innerHTML='<br/>' + settingsAry[settings].message;
 				color = settingsAry[settings].color;
@@ -5735,7 +5562,6 @@ var Helper = {
 		var nextPage=currentPage+1;
 		document.getElementById('compSum').innerHTML+=nextPage+', ';
 		var doc=System.createDocument(responseText);
-		//~ var compList = System.findNodes('//a[contains(@href,"cmd=profile&subcmd=destroycomponent&component_id=")]/img',doc);
 		$(responseText).find('a[href*="cmd\=profile\&subcmd\=destroycomponent\&component_id\="]').each(function() {
 
 				var img=$(this).children(':first');
@@ -6105,9 +5931,6 @@ var Helper = {
 			{'id':'showAmuletTypeItems', 'type':'Amulet'},
 			{'id':'showRuneTypeItems', 'type':'Rune'}
 		];
-		//~ for (var i=0; i<Helper.itemFilters.length; i += 1) {
-			//~ System.setDefault(Helper.itemFilters[i].id, true);
-		//~ }
 	},
 
 	inventoryManagerHeaders: function(reportType, targetInventory, targetID) {
@@ -6328,7 +6151,7 @@ var Helper = {
 		}*/
 		targetInventory.lastUpdate = new Date();
 		// Sets but never gets inventory!
-		//~ System.setValueJSON(inventoryShell, targetInventory);
+		// System.setValueJSON(inventoryShell, targetInventory);
 
 		var inventoryTable=document.getElementById('Helper:InventoryTable');
 		for (i=0; i<inventoryTable.rows[0].cells.length; i += 1) {
@@ -7099,19 +6922,19 @@ var Helper = {
 			}
 		}
 		var attackValue        = System.findNode('//td[@title="attackValue"]');
-		var attackNumber           = System.intValue(attackValue.innerHTML);
+		var attackNumber       = System.intValue(attackValue.innerHTML);
 		attackValue.innerHTML  = System.addCommas(attackNumber - Math.round(totalMercAttack*0.2));
 		var defenseValue       = System.findNode('//td[@title="defenseValue"]');
-		var defenseNumber          = System.intValue(defenseValue.innerHTML);
+		var defenseNumber      = System.intValue(defenseValue.innerHTML);
 		defenseValue.innerHTML = System.addCommas(defenseNumber - Math.round(totalMercDefense*0.2));
 		var armorValue         = System.findNode('//td[@title="armorValue"]');
-		var armorNumber            = System.intValue(armorValue.innerHTML);
+		var armorNumber        = System.intValue(armorValue.innerHTML);
 		armorValue.innerHTML   = System.addCommas(armorNumber - Math.round(totalMercArmor*0.2));
 		var damageValue        = System.findNode('//td[@title="damageValue"]');
-		var damageNumber           = System.intValue(damageValue.innerHTML);
+		var damageNumber       = System.intValue(damageValue.innerHTML);
 		damageValue.innerHTML  = System.addCommas(damageNumber - Math.round(totalMercDamage*0.2));
 		var hpValue            = System.findNode('//td[@title="hpValue"]');
-		var hpNumber               = System.intValue(hpValue.innerHTML);
+		var hpNumber           = System.intValue(hpValue.innerHTML);
 		hpValue.innerHTML      = System.addCommas(hpNumber - Math.round(totalMercHP*0.2));
 	},
 
@@ -8135,8 +7958,8 @@ var Helper = {
 			obj.class   = $('#dialog-viewcreature')
 				.find('span.classification')
 				.text();
-			//~ obj.level   = System.intValue($('#dialog-viewcreature')
-				//~ .find('span.level').text());
+			// obj.level   = System.intValue($('#dialog-viewcreature')
+				// .find('span.level').text());
 			obj.attack  = System.intValue($('#dialog-viewcreature')
 				.find('dd.attribute-atk').text());
 			obj.defense = System.intValue($('#dialog-viewcreature')
@@ -8154,8 +7977,8 @@ var Helper = {
 			obj.name    = System.findNode('//td/font[@size="3"][b]')
 				.textContent.trim();
 			obj.class   = creatureStatTable.rows[1].cells[1].textContent;
-			//~ obj.level   = System.intValue(creatureStatTable.rows[1].cells[3]
-				//~ .textContent);
+			// obj.level   = System.intValue(creatureStatTable.rows[1].cells[3]
+				// .textContent);
 			obj.attack  = System.intValue(creatureStatTable.rows[2].cells[1]
 				.textContent);
 			obj.defense = System.intValue(creatureStatTable.rows[2].cells[3]
@@ -8308,10 +8131,6 @@ var Helper = {
 	},
 
 	evalDefence: function(combat) {
-
-//~ var overallDefenseValue = (groupExists?groupDefenseValue:playerDefenseValue) +
-//~ 
-//~ Math.floor((groupExists?groupDefenseValue:playerDefenseValue) * constitutionLevel * 0.001) + nightmareVisageAttackMovedToDefense;
 
 		combat.overallDefenseValue = (combat.callback.groupExists ?
 			combat.callback.groupDefenseValue : combat.player.defenseValue) +
@@ -8638,7 +8457,7 @@ var Helper = {
 		bioEditLinesDiv.innerHTML += ' Display <input id="Helper:linesToShow"' +
 			' type="number" min="0" max="99" value="' + System.getValue('bioEditLines') +
 			'"/> Lines' +
-		//~ ' <input type="button" style="display:none" id="Helper:saveLines" value="Update Rows To Show" class="custombutton"/>';
+		// ' <input type="button" style="display:none" id="Helper:saveLines" value="Update Rows To Show" class="custombutton"/>';
 		' <input type="button" id="Helper:saveLines" value="Update Rows To Show" class="custombutton"/>';
 		document.getElementById('Helper:saveLines').addEventListener('click',
 			function() {
@@ -9182,7 +9001,7 @@ var Helper = {
 
 		var arenaTable = System.findNode('//table[@width=620]/tbody/tr/td[contains(.,"Reward")]/table');
 
-		//~ var arenaMoves = System.getValueJSON('arenaMoves');
+		// var arenaMoves = System.getValueJSON('arenaMoves');
 		var oldArenaMatches = System.getValueJSON('arenaMatches');
 		var arenaMatches;
 		var aMatch;
@@ -9385,7 +9204,7 @@ var Helper = {
 		} catch (err) {
 			console.log(err);
 		}
-		//~ var lastCheck=new Date(parseInt(System.getValue('lastVersionCheck'),10));
+		// var lastCheck=new Date(parseInt(System.getValue('lastVersionCheck'),10));
 		var buffs=System.getValue('huntingBuffs');
 		var buffsName=System.getValue('huntingBuffsName');
 		var buffs2=System.getValue('huntingBuffs2');
@@ -9441,7 +9260,7 @@ var Helper = {
 			'<tr><td align="right">' + Layout.networkIcon + 'Enable Temple Alert' + Helper.helpLink('Enable Temple Alert', 'Puts an alert on the LHS if you have not prayed at the temple today.') +
 				':</td><td><input name="enableTempleAlert" type="checkbox" value="on"' + (System.getValue('enableTempleAlert')?' checked':'') + '></td></tr>' +
 
-			'<tr><td align="right">' + Layout.networkIcon +'Enable Gold ' +
+			'<tr><td align="right">' + Layout.networkIcon + 'Enable Gold ' +
 				'Upgrade Alert' + Helper.helpLink('Enable Gold Upgrade Alert',
 				'Puts an alert on the LHS if you have not upgraded your ' +
 				'stamina with gold today.') +
@@ -9491,7 +9310,7 @@ var Helper = {
 				'Champions will be colored green, Elites yellow and Super Elites red.') +
 				':</td><td><input name="enableCreatureColoring" type="checkbox" value="on"' + (System.getValue('enableCreatureColoring')?' checked':'') + '></td></td></tr>' +
 			'<tr><td align="right">'+Layout.networkIcon+'Show Creature Info' + Helper.helpLink('Show Creature Info', 'This will show the information from the view creature link when you mouseover the link.' +
-				//~ (System.browserVersion<3?'Does not work in Firefox 2 - suggest disabling or upgrading to Firefox 3.':'')) +
+				// (System.browserVersion<3?'Does not work in Firefox 2 - suggest disabling or upgrading to Firefox 3.':'')) +
 				'') +
 				':</td><td><input name="showCreatureInfo" type="checkbox" value="on"' + (System.getValue('showCreatureInfo')?' checked':'') + '></td></tr>' +
 
@@ -9802,7 +9621,7 @@ var Helper = {
 			System.setValue('CombatLog', combatLog);
 		}
 
-		//~ var playerName = $('dt[id="statbar-character"]').html();
+		// var playerName = $('dt[id="statbar-character"]').html();
 		var yuuzParser = '<tr><td align="center" colspan="4"><b>Log Parser</b></td></tr>'+
 			'<tr><td colspan="4" align="center">WARNING: this links to an external site not related to HCS.<br />' +
 			'If you wish to visit site directly URL is: http://evolutions.yvong.com/fshlogparser.php<br />'+
@@ -9857,7 +9676,7 @@ var Helper = {
 
 	notepadClearLog: function() {
 		if (window.confirm('Are you sure you want to clear your log?')) {
-			//~ var combatLog=document.getElementById('Helper:CombatLog');
+			// var combatLog=document.getElementById('Helper:CombatLog');
 			System.setValue('CombatLog', '');
 			window.location = window.location;
 		}
@@ -10082,8 +9901,6 @@ var Helper = {
 	},
 
 	injectQuickLinkManager: function(content) {
-		//~ System.addStyle('.HelperTextLink {color:black;font-size:x-small;cursor:pointer;}\n' +
-			//~ '.HelperTextLink:hover {text-decoration:underline;}\n');
 
 		if (!content) {content = Layout.notebookContent();}
 		content.innerHTML=Helper.makePageTemplate('Quick Links','','','','quickLinkAreaId');
@@ -10109,29 +9926,37 @@ var Helper = {
 	},
 
 	injectInvent: function(){
-		var selector='<tr><td align="center">Select how many to quick invent<input value=1 id="invent_amount" name="invent_amount" size=3 class="custominput"></td></tr>'+
-			'<tr><td align="center"><input id="quickInvent" value="Quick invent items" class="custombutton" type="submit"></td></tr>'+ //button to invennt
+		var selector = '<tr><td align="center">Select how many to quick ' +
+			'invent<input value=1 id="invent_amount" name="invent_amount" ' +
+			'size=3 class="custominput"></td></tr>' +
+			'<tr><td align="center"><input id="quickInvent" value="Quick ' +
+			'invent items" class="custombutton" type="submit"></td></tr>' + //button to invent
 			//'<input type="hidden" id="recipe_id" value="'+ recipeID +'">'+
-			'<tr><td colspan=6 align="center"><span id="invet_Result_label"></span><ol id="invent_Result"></ol></td></tr>';
+			'<tr><td colspan=6 align="center"><span id="invet_Result_label">' +
+			'</span><ol id="invent_Result"></ol></td></tr>';
 		//injectHere.parentNode.innerHTML+=selector;
 		$('input[name="recipe_id"]').closest('tbody').append(selector);
-		document.getElementById('quickInvent').addEventListener('click', Helper.quickInvent, true);
+		document.getElementById('quickInvent').addEventListener('click',
+			Helper.quickInvent, true);
 
 	},
 
 	quickInvent: function() {
 		var amountToInvent = $('#invent_amount').attr('value');
 		var recipeID = $('input[name="recipe_id"]').attr('value');
-		$('#invet_Result_label').html('Inventing '+amountToInvent+' Items');
-		for (var i=0;i<amountToInvent;i += 1) {
+		$('#invet_Result_label').html('Inventing ' + amountToInvent + ' Items');
+		for (var i = 0; i < amountToInvent; i += 1) {
 			//Had to add &fsh=i to ensure that the call is sent out multiple times.
-			System.xmlhttp('index.php?cmd=inventing&subcmd=doinvent&recipe_id='+recipeID+'&fsh='+i, Helper.quickInventDone);
+			System.xmlhttp(
+				'index.php?cmd=inventing&subcmd=doinvent&recipe_id=' +
+				recipeID + '&fsh=' + i, Helper.quickInventDone);
 		}
 	},
 
 	quickInventDone: function(responseText) {
 		var infoMessage = Layout.infoBox(responseText);
-		$('#invent_Result').append('<li style="list-style:decimal">'+infoMessage+'</li>');
+		$('#invent_Result').append('<li style="list-style:decimal">' +
+			infoMessage + '</li>');
 	},
 
 	toggleQuickTake: function(){
@@ -10691,7 +10516,6 @@ var Helper = {
 		var breaker=document.createElement('BR');
 		injectHere.parentNode.insertBefore(breaker, injectHere.nextSibling);
 		injectHere.parentNode.insertBefore(displayList, injectHere.nextSibling);
-		//~ var test = document.getElementById('Helper:resetBountyList').addEventListener('click', Helper.resetBountyList, true);
 		document.getElementById('Helper:resetBountyList').addEventListener('click', Helper.resetBountyList, true);
 	},
 
@@ -10786,7 +10610,7 @@ var Helper = {
 			System.xmlhttp('index.php?cmd=profile',
 				Helper.parseProfileForWorld, refreshAllyEnemyDataOnly);
 		} else {
-			//~ contactList = System.getValueJSON('contactList');
+			// contactList = System.getValueJSON('contactList');
 			contactList.isRefreshed = false;
 			Helper.injectAllyEnemyList(contactList);
 		}
@@ -10924,7 +10748,7 @@ var Helper = {
 			onlineAlliesEnemies = onlineAlliesEnemies.filter(function(e) {return e.type!=='Enemy';});
 		}
 		if (onlineAlliesEnemies.length === 0) {return;}
-		//~ var playerId = Layout.playerId();
+		// var playerId = Layout.playerId();
 		var injectHere = document.getElementById('Helper:AllyEnemyListPlaceholder');
 		var displayList = document.createElement('TABLE');
 		//displayList.style.border = '1px solid #c5ad73';
@@ -11494,7 +11318,7 @@ var Helper = {
 		//find the time the guild log was stored last
 		Helper.storedGuildLog = System.getValueJSON('storedGuildLog');
 		if (Helper.storedGuildLog) {
-			//~ var lastMessageIndex = Helper.storedGuildLog.logMessage.length;
+			// var lastMessageIndex = Helper.storedGuildLog.logMessage.length;
 			Helper.lastStoredGuildLogMessage = Helper.storedGuildLog.logMessage[0].logMessage;
 			Helper.lastStoredGuildLogMessagePostTime = Helper.storedGuildLog.logMessage[0].postDateAsLocalMilli;
 		}
@@ -11869,13 +11693,12 @@ var Helper = {
 
 	injectTempleAlert: function() { //jquery
 		//Checks to see if the temple is open for business.
-		if (!System.getValue('enableTempleAlert')) {return;}
+		//if (!System.getValue('enableTempleAlert')) {return;}
 		if (System.getUrlParameter('cmd') === 'temple') {return;}
 		var templeAlertLastUpdate = System.getValue('lastTempleCheck');
 		var needToPray = System.getValue('needToPray');
 		var needToParse = false;
 		if (templeAlertLastUpdate) {
-			//~ if (Date.now() - templeAlertLastUpdate > 60 * 60 * 1000) { // TODO midnight
 			if (Date.now() > templeAlertLastUpdate) { // midnight
 				needToParse = true;
 			} else if (needToPray) {
@@ -11917,7 +11740,7 @@ displayDisconnectedFromGodsMessage: function() {
 	},
 
 	injectUpgradeAlert: function() { //jquery
-		if (!System.getValue('enableUpgradeAlert')) {return;}
+		//if (!System.getValue('enableUpgradeAlert')) {return;}
 		if (window.location.search.search('cmd=points&type=1') !== -1) {return;}
 		var needToDoUpgrade = System.getValue('needToDoUpgrade');
 		if (needToDoUpgrade) {
@@ -11925,9 +11748,7 @@ displayDisconnectedFromGodsMessage: function() {
 			return;
 		}
 		var lastUpgradeCheck = System.getValue('lastUpgradeCheck');
-		if (lastUpgradeCheck && Date.now() < lastUpgradeCheck) {
-			return;
-		}
+		if (lastUpgradeCheck && Date.now() < lastUpgradeCheck) {return;}
 		$.get('index.php?cmd=points&type=1', Helper.parseGoldUpgrades);
 	},
 
@@ -12067,7 +11888,6 @@ displayDisconnectedFromGodsMessage: function() {
 
 	injectFindOther: function(content) {
 		if (!content) {content=Layout.notebookContent();}
-		//~ var buffList = Data.buffList;
 		var injectionText = '';
 		var textToSearchFor = System.getValue('textToSearchFor');
 		var extraProfile = System.getValue('extraProfile');
@@ -12261,7 +12081,6 @@ displayDisconnectedFromGodsMessage: function() {
 
 	findBuffsParsePlayersForBuffs: function() {
 		//remove duplicates TODO
-		//~ Helper.onlinePlayers = Helper.onlinePlayers.removeDuplicates();
 		var bufferProgress = document.getElementById('bufferProgress');
 		//now need to parse player pages for buff ...
 		document.getElementById('potentialBuffers').innerHTML = Helper.onlinePlayers.length;
@@ -12291,10 +12110,6 @@ displayDisconnectedFromGodsMessage: function() {
 		var lastActivity = /(\d+) mins, (\d+) secs/.exec(lastActivityElement.text());
 		var lastActivityMinutes = parseInt(lastActivity[1],10);
 		var lastActivityIMG = Helper.onlineDot(lastActivityMinutes);
-		//~ var lastActivityIMG = Data.yellowDiamond;
-		//~ if (lastActivityMinutes < 2) {
-			//~ lastActivityIMG = Data.greenDiamond;
-		//~ }
 		//buffs
 		var bioDiv = $(doc).find('div.innerColumnHeader:contains("Biography"):last');
 		var bioCell = bioDiv.next();
@@ -12319,7 +12134,6 @@ displayDisconnectedFromGodsMessage: function() {
 				textLineArray.push(textLine);
 			}
 		}
-		//~ textLineArray = textLineArray.removeDuplicates();
 		textLineArray = System.uniq(textLineArray);
 		//sustain
 		var sustainText = $(doc).find('td:has(a:contains("Sustain")):last').next().find('table.tipped').data('tipped');
@@ -12339,10 +12153,6 @@ displayDisconnectedFromGodsMessage: function() {
 			//name cell
 			var newCell = newRow.insertCell(0);
 			newCell.style.verticalAlign = 'top';
-			//~ lastActivityIMG = Data.yellowDiamond;
-			//~ if (lastActivityMinutes < 2) {
-				//~ lastActivityIMG = Data.greenDiamond;
-			//~ }
 			var playerHREF = callback.href;
 			var bioTip = bioCell.html().replace(/'|"|\n/g,'');
 			newCell.innerHTML = '<nobr>' + lastActivityIMG + '&nbsp;<a href="' + playerHREF + '" target="new" ' +
@@ -12449,10 +12259,9 @@ displayDisconnectedFromGodsMessage: function() {
 			'Character' : [
 				['BL', 'Buff Log', 'injectBuffLog'],
 				['COL', 'Combat Log', 'injectNotepadShowLogs'],
-				//~ ['IM', 'Inventory Manager', 'injectInventoryManager'],
+				// ['IM', 'Inventory Manager', 'injectInventoryManager'],
 				['RM', 'Recipe Manager', 'injectRecipeManager'],
 				['QLM', 'Quick Links', 'injectQuickLinkManager']
-				//, ['CRM', 'Create Maps', 'injectCreateMap']
 			],
 			'Actions' : [
 				['FB', 'Find Buffs', 'injectFindBuffs'],
@@ -12460,16 +12269,15 @@ displayDisconnectedFromGodsMessage: function() {
 				['OP', 'Online Players', 'injectOnlinePlayers'],
 				['QS', 'AH Quick Search', 'injectAuctionSearch']
 			],
-			//~ 'Guild' : [
-				//~ ['GI', 'Guild Inventory', 'injectGuildInventoryManager'],
-				//~ ['GL', 'Guild Log', 'injectNewGuildLog']
-			//~ ],
+			// 'Guild' : [
+				// ['GI', 'Guild Inventory', 'injectGuildInventoryManager'],
+				// ['GL', 'Guild Log', 'injectNewGuildLog']
+			// ],
 			'Extra' : [
-				//~ ['BD', 'Best Damage Items', 'injectCheckWearingItem'],
 				['QE', 'Quick Extract', 'insertQuickExtract'],
 				['QW', 'Quick Wear', 'insertQuickWear'],
 				['BoxL', 'FS Box Log', 'injectFsBoxContent']
-				//~ ['CRL', 'Creature Log', 'injectMonsterLog'] // TODO
+				// ['CRL', 'Creature Log', 'injectMonsterLog']
 			]
 			};
 		var html = '<div style="cursor:default; text-decoration:none; ' +
@@ -12569,15 +12377,14 @@ displayDisconnectedFromGodsMessage: function() {
 	},
 
 	injectComposing: function() { //jquery
-		if (System.getValue('disableComposingPrompts')) {
+		var disableComposingPrompts =
+			System.getValue('disableComposingPrompts');
+		if (disableComposingPrompts) {
 			$('input[class^="large awesome"][onclick]').each(function(i, e) {
 				$(e).attr('onclick', $(e).attr('onclick')
 				.replace(/if\(confirm\(.+\)\) /, ''));
 			});
-			//~ $('input[value^="Instant Finish All"]')
 			$('div#composing-error-dialog')
-				//~ .after('<br><br><b>Warning:</b> Confirmation prompts are ' +
-				//~ 'disabled. Use at your own risk.');
 				.before('<div id="fshCompConf"><b>Warning:</b> Confirmation ' +
 				'prompts are disabled. Use at your own risk.<div>');
 		}
@@ -12589,7 +12396,7 @@ displayDisconnectedFromGodsMessage: function() {
 		if ($('select[id^="composing-template-"][value!="none"]').length) {
 			$('#helperCreateAll').prop('disabled', false);
 			$('#helperCreateAll').click(function() {
-				if (System.getValue('disableComposingPrompts') ||
+				if (disableComposingPrompts ||
 					confirm('Are you sure you want to create all potions? ' +
 						'Do you have the correct templates selected?')) {
 					$('select[id^="composing-template-"][value!="none"]')

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -64,6 +64,8 @@ var Helper = {
 				Helper.injectTempleAlert();}
 			if (System.getValue('enableUpgradeAlert')) {
 				Helper.injectUpgradeAlert();}
+			if (System.getValue('enableComposingAlert')) {
+				Helper.injectComposeAlert();}
 			Helper.injectQuickMsgDialogJQ();
 		}
 
@@ -1932,28 +1934,6 @@ var Helper = {
 		}
 		if (obj === undefined) {return def;}
 		return obj;
-	},
-
-	questStatusSort: function(a,b) {
-		var result=0;
-		var valueA,valueB;
-		var statuses = ['Incomplete', 'Complete', ''];
-		if (!a[Helper.sortBy]) {
-			valueA=Helper.sortAsc?50:-50;
-		}
-		else {
-			valueA=statuses.indexOf(a[Helper.sortBy]);
-		}
-		if (!b[Helper.sortBy]) {
-			valueB=Helper.sortAsc?50:-50;
-		}
-		else {
-			valueB=statuses.indexOf(b[Helper.sortBy]);
-		}
-
-		result = valueA-valueB;
-		if (!Helper.sortAsc) {result=-result;}
-		return result;
 	},
 
 	oldRemoveBuffs: function() {
@@ -4548,14 +4528,14 @@ var Helper = {
 	getMembrList: function(fn, force) {
 		if (force) {
 			$.ajax({
-				cache: false,
+				//cache: false,
 				dataType: 'json',
 				url:'index.php',
 				data: {
 					cmd: 'export',
 					subcmd: 'guild_members',
-					guild_id: Layout.guildId(),
-					_rnd: Math.floor(Math.random() * 8999999998) + 1000000000
+					guild_id: Layout.guildId()//,
+					// _rnd: Math.floor(Math.random() * 8999999998) + 1000000000
 				},
 				success: function(data) {
 					var fn = this;
@@ -5829,7 +5809,6 @@ var Helper = {
 	},
 
 	removeHTML: function(buffName) {
-
 		return buffName.replace(/<\/?[^>]+(>|$)/g, '').replace(/[^a-zA-Z 0-9]+/g,'');
 	},
 
@@ -5910,22 +5889,6 @@ var Helper = {
 			'categoryField':'category',
 			'showRawEditor':true};
 		Helper.generateManageTable();
-	},
-
-	linkFromMouseover: function(mouseOver) {
-		//fetchitem.php?item_id=9206&inv_id=256710069&t=1&p=1346893&currentPlayerId=1346893&extra=5
-		var reParams=/item_id=(\d+)\&inv_id=([-0-9]*)\&t=(\d+)\&p=(\d+)/;
-		var reResult=reParams.exec(mouseOver);
-		if (reResult === null) {
-			return null;
-		}
-		var itemId=reResult[1];
-		var invId=reResult[2];
-		var type=reResult[3];
-		var pid=reResult[4];
-		var theUrl = 'fetchitem.php?item_id=' + itemId + '&inv_id=' + invId + '&t='+type + '&p='+pid;
-		theUrl = System.server + theUrl;
-		return theUrl;
 	},
 
 	linkFromMouseoverCustom: function(mouseOver) {
@@ -7219,489 +7182,61 @@ var Helper = {
 	},
 
 	injectQuickBuff: function() {
-		//~ System.addStyle('.HelperTextLink {color:white;font-size:x-small;cursor:pointer;}\n' +
-			//~ '.HelperTextLink:hover {text-decoration:underline;}\n');
-		//var playerInput = System.findNode('//input[@name="targetPlayers"]');
 		var playerInput = $('input#targetPlayers');
 		if (playerInput.length === 0) {return;}
-		//~ var buffMe = document.createElement('SPAN');
-		//~ buffMe.innerHTML='[self]';
-		//~ buffMe.className='HelperTextLink';
-		//~ buffMe.addEventListener('click', Helper.quickBuffMe, true);
-		//playerInput.parentNode.appendChild(buffMe);
-		//~ playerInput.parent().append(buffMe);
-
-		//~ Helper.injectBuffPackArea();
-
-		//~ var playerIDRE = /tid=(\d+)/;
-		//~ var playerID = playerIDRE.exec(location);
-		//~ if (playerID) {
-			//~ playerID = playerID[1];
-			//~ System.xmlhttp('index.php?cmd=profile&player_id=' + playerID, Helper.getPlayerBuffs, false);
-		//~ }
-		//~ var playerName = /quickbuff&t=([a-zA-Z0-9]+)/.exec(location);
-		//~ if (playerName) {
-			//~ playerName = playerName[1];
-			//~ if (playerName === System.getValue('CharacterName')) System.xmlhttp('index.php?cmd=profile', Helper.getPlayerBuffs, false);
-			//~ else System.xmlhttp('index.php?cmd=findplayer&search_active=1&search_level_max=&search_level_min=&search_username=' + playerName + '&search_show_first=1', Helper.getPlayerBuffs, false);
-		//~ }
+		$('h1:contains("Quick Buff")').after(Layout.quickBuffHeader);
 		System.xmlhttp('index.php?cmd=profile', Helper.getSustain);
-
-		//~ var buffList = Data.buffList;
-		//~ var skillNodes = System.findNodes('//input[@name="skills[]"]');
-		//~ var buffIndex = window.location.toString().indexOf('&blist=');
-//~ 
-		//~ var addr;
-		//~ var newStaminaTotal;
-		//~ var targetPlayersCount;
-		//~ var i;
-//~ 
-		//~ if (buffIndex !== -1) {
-			//~ addr = window.location.toString().substring(buffIndex + 7);
-			//~ addr = addr.substring(0, addr.length - 1).split(';');
-		//~ }
-		//~ var buffPacksToUse = [];
-		//~ if (skillNodes) {
-			//~ var targetPlayers = playerInput;
-			//~ targetPlayersCount = targetPlayers.val().split(',').length*1;
-			//~ newStaminaTotal = 0;
-			//~ var theBuffPack = System.getValueJSON('buffpack'); // cache it now in case we have a buff pack to find.
-			//~ for (i = 0; i < skillNodes.length; i+= 1 ) {
-				//var skillName = skillNodes[i].parentNode.parentNode.textContent.match(/\t([A-Z].*) \[/)[1];
-				//~ var skillName = skillNodes[i].getAttribute('data-name');
-				//skillNodes[i].setAttribute('skillName', skillName); // Use data-name instead
-				//~ for (var k = 0; k < buffList.length; k += 1) {
-					//~ if (buffList[k].name !== skillName) {continue;}
-					//~ if (!addr) {break;}
-					//~ for (var p = 0; p < addr.length; p += 1) {
-//~ 
-						//~ if (addr[p] === k) {
-//~ 
-							//~ newStaminaTotal += buffList[k].stamina*1;
-							//~ skillNodes[i].checked = true;
-						//~ } else if (addr[p] >= 126) {
-							//~ if (!theBuffPack) {continue;}
-//~ 
-							//~ var bpIndex = addr[p] - 126;
-							//~ var bpButton = document.getElementById('bpSelect' + bpIndex);
-//~ 
-							//~ if (!bpButton) {continue;}
-							//~ var foundMe = false;
-							//~ for (var indx = 0; indx < buffPacksToUse.length; indx += 1) {
-								//~ if (buffPacksToUse[indx] === bpIndex) {
-									//~ foundMe = true;
-									//~ break;
-								//~ }
-							//~ }
-							//~ if (!foundMe) {
-								//~ buffPacksToUse.push(bpIndex);
-							//~ }
-								//continue;
-						//~ }
-					//~ }
-					//skillNodes[i].setAttribute('staminaCost',buffList[k].stamina); // Use data-cost instead
-				//~ }
-				//~ skillNodes[i].addEventListener('click', Helper.toggleBuffStatus, true);
-			//~ }
-		//~ }
-		//~ //var activateButton = System.findNode('//input[@value="Activate Selected Skills"]');
-		//var activateButton = $('input[value="Activate Selected Skills"]');
-		//~ var activateButton = $('table#bpTable');
-		//~ activateButton.parent().append('<br><span style="color:white;">Stamina to cast selected skills: <span>' +
-			//~ '<span id="staminaTotal" style="display:none; color:orange;">' + newStaminaTotal +
-			//~ '</span>&nbsp;<span id="staminaTotalAll" style="color:orange;">' + newStaminaTotal * targetPlayersCount + '</span>');
-		//~ if (buffPacksToUse.length > 0) {
-			//~ for (i = 0; i < buffPacksToUse.length; i+= 1 ) {
-				//~ Helper.useBuffPack(buffPacksToUse[i]);
-			//~ }
-		//~ }
-		//~ //code to pre-size cell for data later. crude but it works.
-		//~ $('input[value="activate"]').next().find('tr:last td').html('&nbsp;</br>&nbsp;</br>&nbsp;');
+		$('div#packs').on('click', 'h1', window.updateCost);
+		$('div#players').on('click', 'h1', Helper.addBuffLevels);
 	},
 
-	toggleBuffStatus: function(evt) {
-		var staminaTotal = System.findNode('//span[@id="staminaTotal"]');
-		var staminaTotalAll = System.findNode('//span[@id="staminaTotalAll"]');
-		var targetPlayers = System.findNode('//input[@name="targetPlayers"]');
-		var targetPlayersCount = targetPlayers.value.split(',').length*1;
-		var newStaminaTotal = 0;
-		if (evt.target.checked === false) {
-			evt.target.checked = false;
-			newStaminaTotal = staminaTotal.textContent*1 - evt.target.getAttribute('data-cost')*1;
-			staminaTotal.innerHTML = newStaminaTotal;
-			staminaTotalAll.innerHTML = newStaminaTotal * targetPlayersCount;
-		}
-		else if (evt.target.checked === true) {
-			evt.target.checked = true;
-			newStaminaTotal = staminaTotal.textContent*1 + evt.target.getAttribute('data-cost')*1;
-			staminaTotal.innerHTML = newStaminaTotal;
-			staminaTotalAll.innerHTML = newStaminaTotal * targetPlayersCount;
-		}
+	addBuffLevels: function() {
+		$('span.fshSelf').remove();
+		var self = $(this);
+		Helper.addStatsQuickBuff(self);
+		var buffs = self.data('buffs').split(',');
+		var hash = {};
+		self.next().find('span').each(function(i, e) {
+			hash[buffs[i]] = $(e).text().replace(/\[|\]/g, '');
+		});
+		Object.keys(hash).forEach(function(value) {
+			var buffLvl = parseInt(hash[value], 10);
+			var label = $('label[for="skill-' + value + '"]');
+			if (label.length === 0) {return;}
+			var span = $('span > span', label);
+			var myLvl = parseInt(span.text().replace(/\[|\]/g, ''), 10);
+			span.after('<span class="fshSelf"' + (myLvl > buffLvl ?
+				' style="color:red;"' : ' style="color:green;"') + '> [' +
+				buffLvl + ']</span>');
+		});
 	},
 
-	injectBuffPackArea: function() {
-		Helper.injectBuffPackList();
-		Helper.injectBuffPackAddButton();
-	},
-
-	injectBuffPackList: function() {
-		var injectHere = System.findNode("//input[@value='Activate Selected Skills']/parent::*/parent::*");
-		var bpArea = document.createElement("SPAN");
-		bpArea.innerHTML="<br><div align='center'><span style='color:lime; font-size:large;'>Buff Packs</span><table id='bpTable' width='600' style='border:1px solid #A07720;' rules=rows><tbody>" +
-			"<tr><td style='color:gold; font-weight:bold;'>Nickname</td><td style='color:gold; font-weight:bold;'>Buffs included in the pack</td>" +
-			"<td><span id=bpSelectAll class='HelperTextLink'>[All]</span>&nbsp;<span id=bpClear class='HelperTextLink'>[Clear]</span></td></tr>" +
-			"</tbody></table></div>";
-		bpArea.style.color='white';
-		injectHere.appendChild(bpArea);
-
-		document.getElementById("bpSelectAll").addEventListener("click", function() {Helper.setAllSkills(true);}, false);
-		document.getElementById("bpClear").addEventListener("click", function() {Helper.setAllSkills(false);}, false);
-		document.getElementById("selectAllButton").addEventListener("click", function() {setTimeout(function(){Helper.sumStamCostOfSelectedBuffs();},0);}, false);	
-		
-		var theBuffPack = System.getValueJSON("buffpack");
-		if (!theBuffPack) {return;}
-
-		if (!theBuffPack.nickname) { //avoid bugs if the new array is not populated yet
-			theBuffPack.nickname = {};
-		}
-		if (!theBuffPack.staminaTotal) { //avoid bugs if the new array is not populated yet
-			theBuffPack.staminaTotal = {};
-		}
-
-		var bpTable = document.getElementById('bpTable');
-		for (var i = 0; i < theBuffPack.size; i += 1) {
-			var myRow = bpTable.insertRow(-1);
-			var nickname = theBuffPack.nickname[i]? theBuffPack.nickname[i]:'';
-			var listOfBuffs = theBuffPack.bp[i];
-			var staminaTotal = theBuffPack.staminaTotal[i]? theBuffPack.staminaTotal[i]:'';
-			myRow.innerHTML = '<td>' + nickname + '</td><td style="font-size:x-small;">' + listOfBuffs + '&nbsp;' + staminaTotal + '&nbsp;' +
-				'</td><td><span id=bpSelect' + i + ' class="HelperTextLink" buffId=' + i + '>[Select]</span> ' +
-				'<span id=bpDelete' + i + ' buffId=' + i + ' class="HelperTextLink">[X]</span></td>';
-			document.getElementById('bpSelect' + i).addEventListener('click', Helper.useBuffPackHandler, true);
-			document.getElementById('bpDelete' + i).addEventListener('click', Helper.deleteBuffPack, true);
-		}
-	},
-
-	setAllSkills: function(value) {
-		var skillNodes = System.findNodes('//input[@name="skills[]"]');
-		if (!skillNodes) {return;}
-
-		for (var i = 0; i < skillNodes.length; i+= 1 ) {
-			skillNodes[i].checked = value;
-		}
-		Helper.sumStamCostOfSelectedBuffs();
-	},
-
-	sumStamCostOfSelectedBuffs: function() {
-		var skillNodes = System.findNodes('//input[@name="skills[]"]');
-		if (!skillNodes) {return;}
-
-		var staminaRunningTotal = 0;
-		for (var i = 0; i < skillNodes.length; i+= 1 ) {
-			if (skillNodes[i].checked) {
-				staminaRunningTotal += skillNodes[i].getAttribute('data-cost')*1;
+	addStatsQuickBuff: function(self) {
+		self.parent().find('span.fshLastActivity').remove();
+		$.ajax({
+			cache: false,
+			dataType: 'json',
+			url: 'index.php',
+			data: {
+				cmd:             'export',
+				subcmd:          'profile',
+				player_username: self.text()
+			},
+			success: function(data) {
+				//console.log('7344 data', data);
+				self.after('<span class="fshLastActivity">' +
+					System.formatLastActivity(data.last_login) +
+					'<br>Stamina: ' + data.current_stamina + ' / ' +
+					data.stamina + ' ( ' + Math.floor(data.current_stamina /
+					data.stamina * 100) + '% )' +
+					'</span>');
 			}
-		}
-
-		var staminaTotal = System.findNode('//span[@id="staminaTotal"]');
-		staminaTotal.innerHTML = staminaRunningTotal;
-		var staminaTotalAll = System.findNode('//span[@id="staminaTotalAll"]');
-		var targetPlayers = System.findNode('//input[@name="targetPlayers"]');
-		var targetPlayersCount = targetPlayers.value.split(',').length*1;
-		staminaTotalAll.innerHTML = staminaRunningTotal * targetPlayersCount;
-	},
-
-	useBuffPackHandler: function(evt) {
-		var bpIndex=evt.target.getAttribute('buffId');
-		Helper.useBuffPack(bpIndex);
-	},
-
-	useBuffPack: function(bpIndex) {
-
-		var theBuffPack = System.getValueJSON('buffpack');
-		if (!theBuffPack) {return;}
-		if (bpIndex >= theBuffPack.size) {return;}
-
-		var buffList = theBuffPack.bp[bpIndex];
-		if (!buffList) {return;}
-
-		var skillNodes = System.findNodes('//input[@name="skills[]"]');
-		if (!skillNodes) {return;}
-
-		for (var i = 0; i < skillNodes.length; i+= 1 ) {
-			var skillName = skillNodes[i].parentNode.parentNode.textContent.match(/\t([A-Z].*) \[/)[1];
-			if (buffList.indexOf(skillName) >= 0) {
-				skillNodes[i].checked = true;
-			}
-		}
-		Helper.sumStamCostOfSelectedBuffs();
-	},
-
-	deleteBuffPack: function(evt) {
-
-		if (!window.confirm('Are you sure you want to delete the buff pack?')) {return;}
-
-		var bpIndex=parseInt(evt.target.getAttribute('buffId'),10);
-		var theBuffPack = System.getValueJSON('buffpack');
-		if (!theBuffPack) {return;}
-		if (!theBuffPack.size) {return;}
-
-		theBuffPack.size -=1;
-		if (theBuffPack.size === 0) { // avoid bugs :)
-			delete theBuffPack.bp;
-			delete theBuffPack.nickname;
-			delete theBuffPack.staminaTotal;
-			theBuffPack.bp = {};
-			theBuffPack.nickname = {};
-			theBuffPack.staminaTotal = {};
-		}
-		if (!theBuffPack.nickname) { //avoid bugs
-			theBuffPack.nickname = {};
-		}
-		if (!theBuffPack.staminaTotal) { //avoid bugs
-			theBuffPack.staminaTotal = {};
-		}
-		for (var i = bpIndex; i < theBuffPack.size; i += 1) {
-			theBuffPack.bp[i] = theBuffPack.bp[i + 1];
-			//old buff packs won't have the next two values.
-			theBuffPack.nickname[i] = theBuffPack.nickname[i + 1]? theBuffPack.nickname[i + 1]:'';
-			theBuffPack.staminaTotal[i] = theBuffPack.staminaTotal[i + 1]? theBuffPack.staminaTotal[i + 1]:'';
-		}
-
-		delete theBuffPack.bp[theBuffPack.size];
-		if (theBuffPack.nickname[theBuffPack.size]) {
-			delete theBuffPack.nickname[theBuffPack.size];
-		}
-		if (theBuffPack.staminaTotal[theBuffPack.size]) {
-			delete theBuffPack.staminaTotal[theBuffPack.size];
-		}
-
-		System.setValueJSON('buffpack', theBuffPack);
-		location.reload(true);
-	},
-
-	injectBuffPackAddButton: function() {
-		var bpTable = document.getElementById('bpTable');
-		var myRow = bpTable.insertRow(-1);
-		myRow.innerHTML = '<td><input size=10 id="newBuffPackNickname" name="newBuffPackNickname" value="nickname"></td>'+
-			'<td><input size=60 id="newBuffPack" name="newBuffPack" value="full buff names, separated by comma"></td>' +
-			'<td><span id=bpSave class="HelperTextLink">[Save]</span><span id=bpAdd class="HelperTextLink">[add]</span></td>';
-
-		// button handlers
-		document.getElementById('bpAdd').addEventListener('click', Helper.displayAddBuffPack, true);
-		document.getElementById('bpSave').addEventListener('click', Helper.saveBuffPack, true);
-
-		// display [add] only
-		document.getElementById('newBuffPack').style.visibility = 'hidden';
-		document.getElementById('newBuffPackNickname').style.visibility = 'hidden';
-		document.getElementById('bpAdd').style.visibility = '';
-		document.getElementById('bpSave').style.visibility = 'hidden';
-	},
-
-	displayAddBuffPack: function() {
-		var skillNodes = System.findNodes('//input[@name="skills[]"]');
-		if (!skillNodes) {return;}
-		var buffListBox = document.getElementById('newBuffPack');
-		var buffListText = '';
-		for (var i = 0; i < skillNodes.length; i+= 1 ) {
-			var skillName = skillNodes[i].parentNode.parentNode.textContent.match(/\t([A-Z].*) \[/)[1];
-			if (skillNodes[i].checked === true) {
-				buffListText += skillName + ',';
-			}
-		}
-		if (buffListText.length > 0) {
-			buffListText = buffListText.substring(0,buffListText.lastIndexOf(','));
-			buffListBox.value = buffListText;
-		}
-		document.getElementById('newBuffPack').style.visibility = '';
-		document.getElementById('newBuffPackNickname').style.visibility = '';
-		document.getElementById('bpAdd').style.visibility = 'hidden';
-		document.getElementById('bpSave').style.visibility = '';
-	},
-
-	saveBuffPack: function() {
-		if (!document.getElementById('newBuffPack').value) {return;}
-		if (!document.getElementById('newBuffPackNickname').value) {return;}
-
-		var theBuffPack = System.getValueJSON('buffpack');
-		if (!theBuffPack) {
-			theBuffPack = {};
-			theBuffPack.size = 0;
-			theBuffPack.bp = {};
-			theBuffPack.nickname = {};
-			theBuffPack.staminaTotal = {};
-		}
-		if (!theBuffPack.nickname) { //avoid bugs
-			theBuffPack.nickname = {};
-		}
-		if (!theBuffPack.staminaTotal) { //avoid bugs
-			theBuffPack.staminaTotal = {};
-		}
-		theBuffPack.bp[theBuffPack.size] = document.getElementById('newBuffPack').value;
-		theBuffPack.nickname[theBuffPack.size] = document.getElementById('newBuffPackNickname').value;
-		var listOfBuffs = theBuffPack.bp[theBuffPack.size];
-		var buffArray = listOfBuffs.split(',');
-		var buffList = Data.buffList;
-		var staminaTotal = 0;
-		for (var j = 0; j < buffArray.length; j += 1) {
-			for (var k = 0; k < buffList.length; k += 1) {
-				if (buffArray[j].trim() === buffList[k].name) {
-					staminaTotal += buffList[k].stamina;
-					break;
-				}
-			}
-		}
-		theBuffPack.staminaTotal[theBuffPack.size] = '<span style="color:orange;">(' + staminaTotal + ')</span>';
-
-		//increase the size of the array
-		theBuffPack.size += 1;
-
-		// save and reload
-		System.setValueJSON('buffpack', theBuffPack);
-		location.reload(true);
-	},
-
-	quickBuffMe: function() {
-		var playerInput = System.findNode('//input[@name="targetPlayers"]');
-		playerInput.value = $('dt.stat-name:first').next().text()
-			.replace(/,/g,'');
-
-		if (Helper.tmpSelfProfile) {
-			Helper.getPlayerBuffs(Helper.tmpSelfProfile, true);
-		}
-	},
-
-	getPlayerBuffs: function(responseText, keepPlayerInput) {
-		var playerInput;
-		var playerName;
-		var buffRE;
-		var buff;
-		var buffName;
-		//~ var injectHere = $('form:contains("Activate Selected Skills"):last');
-		var resultText = '<center><table align="center"><tr><td colspan="4" style="color:lime;font-weight:bold">Buffs already on player:</td></tr>';
-
-		if (keepPlayerInput) {
-			playerInput = System.findNode('//input[@name="targetPlayers"]');
-			playerName = playerInput.value;
-		}
-
-		//low level buffs used to get the buff above are not really worth casting.
-		var buffs = Data.buffList;
-		var myBuffs = System.findNodes('//font[@size="1"]');
-		for (var i=0;i<myBuffs.length;i += 1) {
-			var myBuff=myBuffs[i];
-			var myBuffName = /([ a-zA-Z]+)\s\[/.exec(myBuff.innerHTML)[1];
-			var buffFound = false;
-			for (var j=0;j<buffs.length;j += 1) {
-				buffName = buffs[j].name;
-				if (myBuffName === buffName) {
-					//fix me - test again once mouseovers are tested in quick buff screen.
-					var onmouseoverText = '<span style="font-weight:bold; color:#FFF380;">' + buffName + '</span><br /><br />Stamina: ' +
-						buffs[j].stamina + '<br>Duration: ' +
-						buffs[j].duration + '<br>Effect: ' +
-						buffs[j].buff;
-					myBuff.setAttribute('class', 'tipped');
-					myBuff.setAttribute('data-tipped', onmouseoverText);
-					buffFound = true;
-					break;
-				}
-			}
-			if (!buffFound) {
-				console.log('Buff typo in data file: "' + myBuffName + '"');
-			}
-			var buffLevelRE = /\[(\d+)\]/;
-			var buffLevel = buffLevelRE.exec(myBuff.innerHTML)[1]*1;
-			if (buffLevel < 75 &&
-				myBuff.innerHTML.search('Counter Attack') === -1 && myBuff.innerHTML.search('Quest Finder') === -1 &&
-				myBuff.innerHTML.search('Death Dealer') === -1 && myBuff.innerHTML.search('Vision') === -1) {
-				myBuff.style.color = 'gray';
-			}
-		}
-
-		//this could be formatted better ... it looks ugly but my quick attempts at putting it in a table didn't work.
-		var doc=System.createDocument(responseText);
-		buffs = $(doc).find('img[src*="/skills/"]');
-		if (buffs.length === 0) {
-			resultText += '<tr><td colspan="4" style="text-align:center;' +
-				'color:white; font-size:x-small">[no buffs]</td></tr>';
-		} else {
-			buffs.each(function(index){
-				//<center><b>Reckoning</b> (Level: 175)</b></center>
-				//<center><b>Doubler<br><br>(Cannot be affected by Spell Breaker or Spell Leech.)<br><br></b> (Level: 1200)</b></center>
-				var onmouseover = $(this).attr('data-tipped');
-				onmouseover = onmouseover.replace('<br><br>(Cannot be affected by Spell Breaker or Spell Leech.)<br><br>','');
-				if (onmouseover.search('Summon Shield Imp') !== -1) {
-					//<center><b>Summon Shield Imp<br>6 HP remaining<br></b> (Level: 150)</b></center>");
-					//<center><b>Summon Shield Imp<br> HP remaining<br></b> (Level: 165)</b></center>");
-					buffRE = /<b>([ a-zA-Z]+)<br>([0-9]+) HP remaining<br><\/b> \(Level: (\d+)\)/;
-					buff = buffRE.exec(onmouseover);
-					if (!buff) {
-						buffRE = /<b>([ a-zA-Z]+)<br> HP remaining<br><\/b> \(Level: (\d+)\)/;
-						buff = buffRE.exec(onmouseover);
-					}
-					if (!buff) {console.log(onmouseover);}
-					buffName = buff[1];
-					buffLevel = buff[3];
-				} else {
-					buffRE = /<b>([ a-zA-Z]+)<\/b> \(Level: (\d+)\)/;
-					buff = buffRE.exec(onmouseover);
-					buffName = buff[1];
-					buffLevel = buff[2];
-				}
-				if (!buffLevel) {buffLevel = 0;} //For when a shield imp runs out but the buff is still there (0HP)
-				resultText += index % 4 === 0? '<tr>':'';
-				resultText += '<td style="color:white; font-size:x-small">' + buffName + '</td><td style="color:silver; font-size:x-small">[' + buffLevel + ']</td>';
-				resultText += index % 4 === 3? '</tr>':'';
-				var hasThisBuff = $('font:contains("' + buffName + ' ["):not(:contains(" ' + buffName + '"))');
-				if (hasThisBuff.length > 0) {
-					buffLevelRE = /\[(\d+)\]/;
-					var myBuffLevel = parseInt(buffLevelRE.exec(hasThisBuff.html())[1],10);
-					if (myBuffLevel > 11 ||
-						buffName === 'Quest Finder') {
-						hasThisBuff.css('color','lime');
-						hasThisBuff.append(' (<font color="#FFFF00">' + buffLevel + '</font>)');
-					}
-				}
-			});
-			resultText += i % 4 === 3? '<td></td></tr>':'';
-		}
-		resultText += '</table></center>';
-
-		var activateButton = System.findNode('//input[@value="Activate Selected Skills"]');
-		var staminaCell = $(doc).find('td:contains("Stamina:"):last').next().find('td:first');
-		var curStamina = System.intValue(staminaCell.text().split('/')[0]);
-		var maxStamina = System.intValue(staminaCell.text().split('/')[1]);
-		var percentageStaminaLeft = Math.round(100.0*curStamina/1.0*maxStamina);
-		staminaCell.append('(' + percentageStaminaLeft + '%)');
-		if (percentageStaminaLeft < 10) {
-			activateButton.parentNode.style.backgroundColor = 'red';
-		}
-
-		var newNode;
-		var lastActivity = $(doc).find('h2:contains("Last Activity"):last');
-		if (lastActivity.length > 0) {
-			newNode = document.createElement('SPAN');
-			newNode.innerHTML = '<br/><center><span style="color:white;" align="center">' + lastActivity.html() + '</span></center><br/>';
-			activateButton.parentNode.parentNode.appendChild(newNode);
-		}
-
-		var statistics = $(doc).find('td:contains("Stamina:"):last').parents('table:first');
-		resultText += '<center><table class="innerContentMiddle">' + statistics.html() + '</table></center>';
-
-		newNode = document.createElement('SPAN');
-		newNode.innerHTML = resultText;
-		activateButton.parentNode.parentNode.appendChild(newNode);
-
-		if (keepPlayerInput) {
-			playerInput = System.findNode('//input[@name="targetPlayers"]');
-			playerInput.value = playerName;
-		}
+		});
 	},
 
 	getSustain: function(responseText) {
 		var doc = System.createDocument(responseText);
-		Helper.tmpSelfProfile = responseText;
-		$('h1:contains("Quick Buff")').after(Layout.quickBuffHeader);
+		var user = $('#statbar-character').html();
 		Helper.getEnhancement(doc, 'Sustain', $('td#fshSus'));
 		Helper.getEnhancement(doc, 'Fury Caster', $('td#fshFur'));
 		Helper.getBuff(doc, 'Guild Buffer', $('td#fshGB'));
@@ -7709,21 +7244,18 @@ var Helper = {
 		Helper.getBuff(doc, 'Extend', $('td#fshExt'));
 		Helper.getBuff(doc, 'Reinforce', $('td#fshRI'));
 		$('span[id*="HelperActivate"]').click(function() {
-			var user = $(doc).find('#statbar-character').html();
-			var buffHref='?cmd=quickbuff&subcmd=activate&targetPlayers=' +
-				user + '&skills[]=' + $(this).attr('buffID');
 			var trigger = $(this);
+			var buffHref='?cmd=quickbuff&subcmd=activate&targetPlayers=' +
+				user + '&skills[]=' + trigger.attr('buffID');
 			$.ajax({
 				url: buffHref,
 				success: function( data ) {
-					if ($(data).find('font:contains("current or higher ' +
-						'level is currently active on")').length > 0 ||
-						$(data).find('font:contains("was activated on")')
-						) {
+					if ($('font:contains("current or higher level is ' +
+						'currently active on")', data).length > 0 ||
+						$('font:contains("was activated on")', data)) {
 							trigger.css('color','lime');
 							trigger.html('On');
 					}
-					
 				}
 			});
 		});
@@ -7744,29 +7276,28 @@ var Helper = {
 		}
 		var enhColor = 'lime';
 		if (enhLevel < 100) {enhColor = 'red';}
-		inject.append('<span style="color: ' + enhColor + ';">' +
+		inject.html('<span style="color: ' + enhColor + ';">' +
 			enhLevel + '%</span>');
 	},
 
 	getBuff: function(doc, buff, inject) {
-		var hasBuff = $(doc)
-			.find('img.tip-static[data-tipped*="' + buff + '"]');
+		var hasBuff = $('img.tip-static[data-tipped*=">' + buff + '<"]', doc);
 		if (hasBuff.length > 0) {
 			var buffTimeToExpire = hasBuff
 				.parents('td:first')
 				.find('nobr')
 				.html();
-			inject.append('<span style="color:lime;">On</span>&nbsp;<span ' +
+			inject.html('<span style="color:lime;">On</span>&nbsp;<span ' +
 				'style="color: white; font-size: x-small;">(' +
 				buffTimeToExpire +')</span>');
 		} else {
 			var elem = $('input[data-name="' + buff + '"]');
 			if (elem.length > 0) {
-				inject.append('<span style="color:red;cursor:pointer;" ' +
+				inject.html('<span style="color:red;cursor:pointer;" ' +
 					'buffID="' + elem.val() + '" id="HelperActivate' +
 					elem.val() + '">Activate</span>');
 			} else {
-				inject.append('<span style="color:red;">Off</span>');
+				inject.html('<span style="color:red;">Off</span>');
 			}
 		}
 	},
@@ -9271,13 +8802,17 @@ var Helper = {
 		var wantedNames = System.getValue('wantedNames');
 		var combatEvaluatorBias = System.getValue('combatEvaluatorBias');
 		var enabledHuntingMode = System.getValue('enabledHuntingMode');
+		var storage = (JSON.stringify(localStorage).length /
+			(5 * 1024 * 1024) * 100).toFixed(2);
 		var configData=
 			'<form><table style="border-spacing: 10px;">' +
 			'<tr><th colspan="2"><b>Fallen Sword Helper configuration ' +
 				'Settings</b></th></tr>' +
 			'<tr><td colspan="2" align=center>' +
 				'<span style="font-size:xx-small">(Current version: ' +
-				(GM_info ? GM_info.script.version : 'unknown') + ')</span>' +
+				(GM_info ? GM_info.script.version : 'unknown') + ')&nbsp;' +
+				'(Storage Used: ' + storage + '% Remaining: ' +
+				(100 - storage) + '%)</span>' +
 			'</td></tr>' +
 			'<tr><td colspan="2" align=center>' +
 			'<span style="font-weight:bold;">Visit the <a href="https://github.com/fallenswordhelper/fallenswordhelper">Fallen Sword Helper web site</a> ' +
@@ -9317,6 +8852,14 @@ var Helper = {
 				'stamina with gold today.') +
 				':</td><td><input name="enableUpgradeAlert" type="checkbox" ' +
 				'value="on"' + (System.getValue('enableUpgradeAlert') ?
+				' checked' : '') + '></td></tr>' +
+
+			'<tr><td align="right">' + Layout.networkIcon + 'Enable ' +
+				'Composing Alert' + Helper.helpLink('Enable Composing Alert',
+				'Puts an alert on the LHS if you have composing slots ' +
+				'available.') +
+				':</td><td><input name="enableComposingAlert" type="checkbox" ' +
+				'value="on"' + (System.getValue('enableComposingAlert') ?
 				' checked' : '') + '></td></tr>' +
 
 			'<tr><td align="right">Enhance Online Dots' + Helper.helpLink('Enhance Online Dots', 'Enhances the green/grey dots by player names to show online/offline status.') +
@@ -11786,7 +11329,7 @@ displayDisconnectedFromGodsMessage: function() {
 		var notificationUl = $('ul#notifications');
 		notificationUl.prepend('<li class="notification"><a href="index.php?cmd=temple">' +
 			'<span class="notification-icon"></span>' +
-			'<p class="notification-content">Bow down to the gods.</p>' +
+			'<p class="notification-content">Bow down to the gods</p>' +
 			'</a></li>');
 	},
 
@@ -11825,6 +11368,50 @@ displayDisconnectedFromGodsMessage: function() {
 
 	displayUpgradeMsg: function() { //jquery
 		$('ul#notifications').prepend(Layout.goldUpgradeMsg);
+	},
+
+	injectComposeAlert: function() { //jquery
+		if (System.getUrlParameter('cmd') === 'composing') {return;}
+		var needToCompose = System.getValue('needToCompose');
+		if (needToCompose) {
+			Helper.displayComposeMsg();
+			return;
+		}
+		var lastComposeCheck = System.getValue('lastComposeCheck');
+		if (lastComposeCheck && Date.now() < lastComposeCheck) {return;}
+		$.get('index.php?cmd=composing', Helper.parseComposing);
+	},
+
+	parseComposing: function(data) { //jquery
+		var doc;
+		if (System.getUrlParameter('cmd') !== 'composing') {
+			doc = data;
+		} else {
+			doc = document;
+		}
+		var openSlots = $('div.composing-potion-time:contains("ETA: Ready to ' +
+			'Collect!"), div.composing-potion-time:contains("ETA: n/a")', doc);
+		if (openSlots.length !== 0) {
+			Helper.displayComposeMsg();
+			System.setValue('needToCompose', true);
+		} else {
+			var timeRE = /ETA:\s*(\d+)h\s*(\d+)m\s*(\d+)s/;
+			var etas = $('div.composing-potion-time', doc);
+			var eta = Infinity;
+			etas.each(function() { // might be better just to look at [0]
+				var timeArr = timeRE.exec($(this).text());
+				if (!timeArr) {return;}
+				var milli = timeArr[1] * 3600000 + timeArr[2] * 60000 +
+					timeArr[3] * 1000 + Date.now();
+				eta = milli < eta ? milli : eta;
+			});
+			System.setValue('needToCompose', false);
+			System.setValue('lastComposeCheck', eta);
+		}
+	},
+
+	displayComposeMsg: function() { //jquery
+		$('ul#notifications').prepend(Layout.composeMsg);
 	},
 
 	injectFindPlayer: function() {
@@ -12428,6 +12015,10 @@ displayDisconnectedFromGodsMessage: function() {
 	},
 
 	injectComposing: function() { //jquery
+
+		if (System.getValue('enableComposingAlert')) {
+			Helper.parseComposing();}
+
 		var disableComposingPrompts =
 			System.getValue('disableComposingPrompts');
 		if (disableComposingPrompts) {
@@ -12537,7 +12128,7 @@ displayDisconnectedFromGodsMessage: function() {
 (function loadScripts () {
 	var o = {
 		css: ['https://fallenswordhelper.github.io/fallenswordhelper/resources/1507/calfSystem.css'],
-		js:  ['https://cdn.jsdelivr.net/localforage/1.2.7/localforage.min.js',
+		js:  ['https://cdn.jsdelivr.net/localforage/1.2.10/localforage.min.js',
 			  'https://fallenswordhelper.github.io/fallenswordhelper/resources/1507/calfSystem.js'],
 		callback: Helper.onPageLoad
 	};

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -9,7 +9,7 @@
 // @include        http://local.huntedcow.com/fallensword/*
 // @exclude        http://forum.fallensword.com/*
 // @exclude        http://wiki.fallensword.com/*
-// @version        1506
+// @version        1507
 // @downloadURL    https://github.com/fallenswordhelper/fallenswordhelper/raw/master/fallenswordhelper.user.js
 // @grant          none
 // ==/UserScript==
@@ -685,7 +685,7 @@ var Helper = {
 		document.getElementById('clearBuffs').addEventListener('click',
 			function() {
 				System.setValue('buffLog','');
-				window.location = window.location;
+				location.reload();
 			}, true
 		);
 		document.getElementById('bufflog').innerHTML=System.getValue('buffLog');
@@ -710,11 +710,16 @@ var Helper = {
 		}
 	},
 
-	injectFsBoxContent: function(content) {
+	injectFsBoxContent: function(content) { //native
 		if (!content) {content = Layout.notebookContent();}
-		content.innerHTML=Helper.makePageTemplate('FS Box Log','','fsboxclear','Clear','fsboxdetail');
-		document.getElementById('fsboxclear').addEventListener('click',function() {System.setValue('fsboxcontent','');window.location=window.location;},true);
-		document.getElementById('fsboxdetail').innerHTML=System.getValue('fsboxcontent');
+		content.innerHTML = Helper.makePageTemplate('FS Box Log', '',
+			'fsboxclear', 'Clear', 'fsboxdetail');
+		document.getElementById('fsboxclear')
+			.addEventListener('click', function() {
+				System.setValue('fsboxcontent','');
+				location.reload();}, true);
+		document.getElementById('fsboxdetail').innerHTML =
+			System.getValue('fsboxcontent');
 	},
 
 	removeGuildAvyImgBorder: function() { //jquery
@@ -752,8 +757,8 @@ var Helper = {
 			guildLogoElement.style.visibility = 'hidden';
 		}
 		var leaveGuildCell = leftHandSideColumnTable.rows[4].cells[1].firstChild;
-		leaveGuildCell.innerHTML += '[ <span style="cursor:pointer; text-decoration:underline;" ' +
-			'id="toggleStatisticsControl" linkto="statisticsControl" title="Toggle Section">X</span> ]';
+		leaveGuildCell.innerHTML += '<span class="fshNoWrap">[ <span style="cursor:pointer; text-decoration:underline;" ' +
+			'id="toggleStatisticsControl" linkto="statisticsControl" title="Toggle Section">X</span> ]</span>';
 		var statisticsControlElement = leftHandSideColumnTable.rows[6].cells[0].firstChild.nextSibling;
 		statisticsControlElement.id = 'statisticsControl';
 		if (System.getValue('statisticsControl')) {
@@ -770,22 +775,27 @@ var Helper = {
 			guildStructureControlElement.style.visibility = 'hidden';
 		}
 
-		document.getElementById('toggleGuildLogoControl').addEventListener('click', System.toggleVisibilty, true);
-		document.getElementById('toggleStatisticsControl').addEventListener('click', System.toggleVisibilty, true);
-		document.getElementById('toggleGuildStructureControl').addEventListener('click', System.toggleVisibilty, true);
+		document.getElementById('toggleGuildLogoControl')
+			.addEventListener('click', System.toggleVisibilty, true);
+		document.getElementById('toggleStatisticsControl')
+			.addEventListener('click', System.toggleVisibilty, true);
+		document.getElementById('toggleGuildStructureControl')
+			.addEventListener('click', System.toggleVisibilty, true);
 
-		$('td:contains("Username"):last').parents('table:first').find('a[href]').each(function(){
+		$('td:contains("Username"):last').parents('table:first')
+			.find('a[href]').each(function(){
 			$(this).after(' <a style="color:blue;font-size:10px;" ' +
-			'href=\'javascript:window.openWindow("index.php?cmd=quickbuff&t='+$(this).text()+'", "fsQuickBuff", 618, 1000, ",scrollbars")\'' +
-			'>[b]</a>');
+			'href=\'javascript:window.openWindow("index.php?cmd=quickbuff&t=' +
+			$(this).text() + '", "fsQuickBuff", 618, 1000, ",scrollbars")\'' +
+			'>[b]</a>'); // FIXME
 		});
 
 		// self recall
 		var selfRecall = leftHandSideColumnTable.rows[22].cells[0];
 		selfRecall.innerHTML+=' [<a href="index.php?cmd=guild&subcmd=' +
-		'inventory&subcmd2=report&user=' +
-		$('dt.stat-name:first').next().text().replace(/,/g,'') +
-		'" title="Self Recall">SR</a>]';
+			'inventory&subcmd2=report&user=' +
+			$('dt.stat-name:first').next().text().replace(/,/g,'') +
+			'" title="Self Recall">SR</a>]';
 
 		//Detailed conflict information
 		if (System.getValue('detailedConflictInfo') === true) {
@@ -2169,7 +2179,7 @@ var Helper = {
 			trackKS.addEventListener('click', function() {
 				System.setValue('trackKillStreak',
 				System.getValue('trackKillStreak') ? false : true);
-				window.location=window.location;
+				location.reload();
 			},true);
 		}
 	},
@@ -2177,15 +2187,17 @@ var Helper = {
 	recastImpAndRefresh: function(responseText) {
 		var doc = System.createDocument(responseText);
 		if (doc) {
-			window.location=window.location;
+			location.reload();
 		}
 	},
 
 	removeSkill: function(evt) {
 		var buffName = evt.target.parentNode.getAttribute('buffName');
 		var buffHref = evt.target.parentNode.getAttribute('buffHref');
-		if (confirm('Are you sure you wish to remove the ' + buffName + ' skill?')) {
-			System.xmlhttp(buffHref, function() {window.location='index.php?cmd=world';});
+		if (confirm('Are you sure you wish to remove the ' + buffName +
+			' skill?')) {
+			System.xmlhttp(buffHref,
+				function() {location.href = 'index.php?cmd=world';});
 		}
 	},
 
@@ -2246,7 +2258,7 @@ var Helper = {
 		} else {
 			System.setValue('playNewMessageSound', true);
 		}
-		window.location.reload();
+		location.reload();
 	},
 
 	isQuestBeingTracked: function(questHREF) {
@@ -2385,7 +2397,7 @@ var Helper = {
 					}else{
 						$('a#toggleSoundLink').html(Data.soundImage);
 					}
-					System.setValue('playNewMessageSound',!System.getValue('playNewMessageSound')); //window.location.reload();
+					System.setValue('playNewMessageSound',!System.getValue('playNewMessageSound'));
 				},true);
 			}
 			var huntingMode = System.getValue('huntingMode');
@@ -2400,7 +2412,7 @@ var Helper = {
 					}else{
 						$('a#HelperToggleHuntingMode').html(Data.huntingOffImage);
 					}
-					System.setValue('huntingMode',!System.getValue('huntingMode')); //window.location.reload();
+					System.setValue('huntingMode',!System.getValue('huntingMode'));
 				},true);
 		}
 	},
@@ -2810,12 +2822,16 @@ var Helper = {
 				mapName.innerHTML += ' <a href=# id="Helper:ToggleFastWalkMode"><img title="' + altText + '" src="' + imgSource + '" border=0 width=10 height=10/></a>';
 				document.getElementById('Helper:ToggleFastWalkMode').addEventListener('click',
 					function() {
-						System.setValue('enableFastWalk',!System.getValue('enableFastWalk')); window.location.reload();
+						System.setValue('enableFastWalk',
+							!System.getValue('enableFastWalk'));
+						location.reload();
 					},true);
 			}
 			document.getElementById('Helper:ToggleHuntingMode').addEventListener('click',
 				function() {
-					System.setValue('huntingMode',!System.getValue('huntingMode')); window.location.reload();
+					System.setValue('huntingMode',
+						!System.getValue('huntingMode'));
+					location.reload();
 				},true);
 
 		}
@@ -2846,8 +2862,9 @@ var Helper = {
 	},
 
 	fixOnlineGuildBuffLinks: function() {
-		$('a[href*="index.php?cmd=quickbuff&t"]').each(function() {
-			$(this).attr('href',$(this).attr('href').replace(/500/g,'1000'));
+		$('a#guild-minibox-action-quickbuff').each(function() {
+			var self = $(this);
+			self.attr('href', self.attr('href').replace(/500/g,'1000'));
 		});
 	},
 
@@ -2930,11 +2947,13 @@ var Helper = {
 		//System.xmlhttp('index.php?cmd=trade');
 		var xcNum = System.getValue('goldConfirm');
 		if (xcNum === '') {
-			window.alert('You have to visit the trade page once to use the send gold functionality');
+			alert('You have to visit the trade page once to use the send gold functionality');
 			return;
 		}
-		var url = 'index.php?cmd=trade&subcmd=sendgold&xc=' + xcNum + '&target_username=' + recipient +'&gold_amount='+ amount;
-		System.xmlhttp(url, Helper.goldToPlayerSent, {'amount': amount, 'recipient': recipient} );
+		var url = 'index.php?cmd=trade&subcmd=sendgold&xc=' + xcNum +
+			'&target_username=' + recipient +'&gold_amount='+ amount;
+		System.xmlhttp(url, Helper.goldToPlayerSent,
+			{'amount': amount, 'recipient': recipient} );
 	},
 
 	goldToPlayerSent: function(responseText, callback) {
@@ -3162,7 +3181,7 @@ var Helper = {
 	},
 
 	extractAllSimilar: function(evt) {
-		if (!window.confirm('Are you sure you want to extract all similar items?')) {return;}
+		if (!confirm('Are you sure you want to extract all similar items?')) {return;}
 		var InventoryIDs=evt.target.getAttribute('invIDs').split(',');
 		//evt.target.parentNode.innerHTML = InventoryIDs;
 		// var output= '';
@@ -3581,7 +3600,7 @@ var Helper = {
 
 	clearEntityLog: function() {
 		System.setValue('monsterLog', '');
-		window.location='index.php?cmd=notepad&blank=1&subcmd=monsterlog';
+		location.href = 'index.php?cmd=notepad&blank=1&subcmd=monsterlog';
 	},
 
 	sortEntityLogTable: function(evt) {
@@ -3789,7 +3808,7 @@ var Helper = {
 				//if fast walk is enabled then use the stored location, otherwise look it up
 				xCoord = enableFastWalk?Helper.xLocation:pos.X;
 				yCoord = enableFastWalk?Helper.yLocation:pos.Y;
-				window.location = 'index.php?cmd=world&subcmd=move&x=' + (xCoord+dx) + '&y=' + (yCoord+dy);
+				location.href = 'index.php?cmd=world&subcmd=move&x=' + (xCoord+dx) + '&y=' + (yCoord+dy);
 				Helper.xLocation+=dx;
 				Helper.yLocation+=dy;
 			}
@@ -3797,7 +3816,10 @@ var Helper = {
 				//if fast walk is enabled then use the stored location, otherwise look it up
 				xCoord = enableFastWalk?Helper.xLocation:pos.X;
 				yCoord = enableFastWalk?Helper.yLocation:pos.Y;
-				System.xmlhttp('index.php?cmd=world&subcmd=move&x=' + (xCoord+dx) + '&y=' + (yCoord+dy), function() {window.location = System.server + 'index.php?cmd=world&subcmd=map';});
+				System.xmlhttp('index.php?cmd=world&subcmd=move&x=' +
+					(xCoord+dx) + '&y=' + (yCoord+dy), function() {
+						location.href = System.server +
+							'index.php?cmd=world&subcmd=map';});
 				Helper.xLocation+=dx;
 				Helper.yLocation+=dy;
 
@@ -3812,7 +3834,7 @@ var Helper = {
 				Helper.killSingleMonster(index);
 			}
 			else {
-				window.location = linkObj.getAttribute('href');
+				location.href = linkObj.getAttribute('href');
 			}
 		}
 	},
@@ -3857,23 +3879,23 @@ var Helper = {
 		case 114: // repair [r]
 			//do not use repair link for new map
 			if ($('#worldPage').length === 0) {
-				window.location = 'index.php?cmd=blacksmith&subcmd=repairall&fromworld=1';
+				location.href = 'index.php?cmd=blacksmith&subcmd=repairall&fromworld=1';
 			}
 			break;
 		case 71: // create group [G]
-			window.location = 'index.php?cmd=guild&subcmd=groups&subcmd2=create&fromworld=1';
+			location.href = 'index.php?cmd=guild&subcmd=groups&subcmd2=create&fromworld=1';
 			break;
 		case 76: // Log Page [L]
-			window.location = 'index.php?cmd=log';
+			location.href = 'index.php?cmd=log';
 			break;
 		case 103: // go to guild [g]
-			window.location = 'index.php?cmd=guild&subcmd=manage';
+			location.href = 'index.php?cmd=guild&subcmd=manage';
 			break;
 		case 106: // join all group [j]
 			if (!System.getValue('enableMaxGroupSizeToJoin')) {
-				window.location = 'index.php?cmd=guild&subcmd=groups&subcmd2=joinall';
+				location.href = 'index.php?cmd=guild&subcmd=groups&subcmd2=joinall';
 			} else {
-				window.location = 'index.php?cmd=guild&subcmd=groups&subcmd2=joinallgroupsundersize';
+				location.href = 'index.php?cmd=guild&subcmd=groups&subcmd2=joinallgroupsundersize';
 			}
 			break;
 		case 49: // [1]
@@ -3887,7 +3909,7 @@ var Helper = {
 			Helper.killMonsterAt(r-48);
 			break;
 		case 98: // backpack [b]
-			window.location = 'index.php?cmd=profile&subcmd=dropitems&fromworld=1';
+			location.href = 'index.php?cmd=profile&subcmd=dropitems&fromworld=1';
 			break;
 		case 115: // use stairs [s]
 			Helper.useStairs(); // this is suspect, is it old map only?
@@ -3896,7 +3918,7 @@ var Helper = {
 			Helper.quickBuyItem();
 			break;
 		case 118: // fast wear manager [v]
-			window.location = 'index.php?cmd=notepad&blank=1&subcmd=quickwear';
+			location.href = 'index.php?cmd=notepad&blank=1&subcmd=quickwear';
 			break;
 		case 121: // fast send gold [y]
 			Helper.sendGoldToPlayer();
@@ -3908,7 +3930,7 @@ var Helper = {
 		case 48: // return to world [0]
 			//do not use if using new map
 			if ($('#worldPage').length === 0) {
-				window.location = 'index.php?cmd=world';
+				location.href = 'index.php?cmd=world';
 			}
 			break;
 		case 109: // map [m]
@@ -3917,7 +3939,7 @@ var Helper = {
 			System.openInTab(System.server + 'index.php?cmd=world&subcmd=map');
 			break;
 		case 112: // profile [p]
-			window.location = 'index.php?cmd=profile';
+			location.href = 'index.php?cmd=profile';
 			break;
 		case 110: // mini map [n]
 			Helper.displayMiniMap();
@@ -4504,7 +4526,7 @@ var Helper = {
 		} else {
 			System.setValue('showExtraLinks', false);
 		}
-		window.location = window.location;
+		location.reload();
 	},
 
 	toggleShowQuickDropLinks: function() {
@@ -4516,7 +4538,7 @@ var Helper = {
 		} else {
 			System.setValue('showQuickDropLinks', false);
 		}
-		window.location = window.location;
+		location.reload();
 	},
 
 	injectReportPaint: function() {
@@ -4757,7 +4779,7 @@ var Helper = {
 				submit: 'Use'
 			},
 			success: function() {
-				window.location = 'index.php?cmd=profile';
+				location.href = 'index.php?cmd=profile';
 			}
 		});
 	},
@@ -4931,7 +4953,7 @@ var Helper = {
 			}
 		}
 		if (haveItems) {
-			setTimeout(function() {window.location=window.location;}, 100);
+			setTimeout(function() {location.reload();}, 100);
 		}
 	},
 
@@ -5168,7 +5190,8 @@ var Helper = {
 	},
 
 	profileSelectAll: function() {
-		$('input.backpackCheckbox:enabled').not(':checked').each(function(){$(this).click();});
+		$('input.backpackCheckbox:enabled').not(':checked')
+			.each(function(){$(this).click();});
 	},
 
 	addStatTotalToMouseover: function() {
@@ -5889,37 +5912,42 @@ var Helper = {
 
 	injectInventoryManager: function() {
 		var content = Layout.notebookContent();
-		content.innerHTML = '<img src = "' + System.imageServer + '/world/actionLoadingSpinner.gif">&nbsp;Getting inventory data...';
-		if (document.location.search.indexOf('subcmd=invmanager') !== -1){
+		content.innerHTML = '<img src = "' + System.imageServer +
+			'/world/actionLoadingSpinner.gif">&nbsp;Getting inventory data...';
+		if (System.getUrlParameter('subcmd') === 'invmanager') {
 			$.getJSON('?cmd=export&subcmd=inventory', Helper.gotInvMan);
-		}else if (document.location.search.indexOf('subcmd=guildinvmanager') !== -1){
-			$.getJSON('?cmd=export&subcmd=guild_store&inc_tagged=1', Helper.gotGuildInvMan);
+		} else if (System.getUrlParameter('subcmd') === 'guildinvmanager') {
+			$.getJSON('?cmd=export&subcmd=guild_store&inc_tagged=1',
+				Helper.gotGuildInvMan);
 		}
 	},
 
 	gotInvMan: function(data) {
 		Helper.inventory = data;
 		Helper.inventory.folders['-1']='Main';
-		Helper.inventoryManagerHeaders('self', Helper.inventory, 'Helper:InventoryManagerOutput');
+		Helper.inventoryManagerHeaders('self', Helper.inventory,
+			'Helper:InventoryManagerOutput');
 	},
 
 	gotGuildInvMan: function(data) {
 		Helper.guildinventory = data;
-		$.getJSON('?cmd=export&subcmd=guild_members&guild_id='+Helper.guildinventory.guild_id, Helper.gotGuildMembers);
+		$.getJSON('?cmd=export&subcmd=guild_members&guild_id=' +
+			Helper.guildinventory.guild_id, Helper.gotGuildMembers);
 	},
 
 	gotGuildMembers: function(data) {
 		var buildJSON='{';
-		for(var x in data){
+		for (var x in data) {
 			if (!data.hasOwnProperty(x)) { continue; }
-			buildJSON+='"'+data[x].id+'":"'+data[x].username+'",';
+			buildJSON += '"' + data[x].id + '":"' + data[x].username + '",';
 		}
-		buildJSON=buildJSON.substring(0, buildJSON.length-1)+'}';
+		buildJSON = buildJSON.substring(0, buildJSON.length - 1) + '}';
 		Helper.guildinventory.members = JSON.parse(buildJSON);
-		Helper.inventoryManagerHeaders('guild', Helper.guildinventory, 'Helper:GuildInventoryManagerOutput');
+		Helper.inventoryManagerHeaders('guild', Helper.guildinventory,
+			'Helper:GuildInventoryManagerOutput');
 	},
 
-	setItemFilterDefault: function() { // FIXME
+	setItemFilterDefault: function() {
 		Helper.itemFilters = [
 			{'id':'showHelmetTypeItems', 'type':'Helmet'},
 			{'id':'showAmorTypeItems', 'type':'Armor'},
@@ -6385,7 +6413,6 @@ var Helper = {
 		setTimeout(function() {
 			Helper.generateInventoryTable();
 		});
-		//window.location=window.location;
 	},
 
 	injectOnlinePlayers: function(content) {
@@ -6416,11 +6443,6 @@ var Helper = {
 		if (refreshButton) {
 			refreshButton.addEventListener('click', Helper.parseOnlinePlayersStart, true);
 		}
-		System.addStyle(
-			'.HelperTableRow1 {background-color:#e7c473;font-size:small}\n' +
-			'.HelperTableRow1:hover {background-color:white}\n' +
-			'.HelperTableRow2 {background-color:#e2b960;font-size:small}\n' +
-			'.HelperTableRow2:hover {background-color:white}');
 		Helper.onlinePlayers = System.getValueJSON('onlinePlayers');
 		Helper.sortOnlinePlayersTable();
 		Helper.generateOnlinePlayersTable();
@@ -6429,7 +6451,7 @@ var Helper = {
 	parseOnlinePlayersStart: function() {
 		// set timer to redisplay the [refresh] button
 		var now=(new Date()).getTime();
-		GM_setValue('lastOnlineCheck', now.toString());
+		System.setValue('lastOnlineCheck', now.toString());
 
 		var refreshButton = document.getElementById('Helper:OnlinePlayersRefresh');
 		refreshButton.style.visibility = 'hidden';
@@ -8466,7 +8488,7 @@ var Helper = {
 					parseInt(theBox.value, 10) < '0' ||
 					parseInt(theBox.value, 10) > '99') {return;}
 				System.setValue('bioEditLines', parseInt(theBox.value, 10));
-				window.location.reload();
+				location.reload();
 			}, true);
 
 		document.getElementById('textInputBox').addEventListener('keyup', Helper.updateBioCharacters, true);
@@ -8575,7 +8597,9 @@ var Helper = {
 		if (window.confirm('Are you sure you with to use a special portal back to Krul Island?')) {
 			var krulXCV = System.getValue('krulXCV');
 			if (krulXCV) {
-				System.xmlhttp('index.php?cmd=settings&subcmd=fix&xcv=' + krulXCV, function() {window.location='index.php?cmd=world';});
+				System.xmlhttp('index.php?cmd=settings&subcmd=fix&xcv=' +
+					krulXCV, function() {location.href = 
+						'index.php?cmd=world';});
 			} else {
 				window.alert('Please visit the preferences page to cache your Krul Portal link');
 			}
@@ -8807,13 +8831,13 @@ var Helper = {
 		if (playerMinLvl.value === '') {playerMinLvl.value = '0';}
 		if (playerMaxLvl.value === '') {playerMaxLvl.value = '9999';}
 		if (!isNaN(playerMinLvl.value)) {
-			System.setValue(minLvlSearchText, parseInt(playerMinLvl.value,10));
+			System.setValue(minLvlSearchText, parseInt(playerMinLvl.value, 10));
 		}
 		if (!isNaN(playerMaxLvl.value)) {
-			System.setValue(maxLvlSearchText, parseInt(playerMaxLvl.value,10));
+			System.setValue(maxLvlSearchText, parseInt(playerMaxLvl.value, 10));
 		}
-		if (href) {window.location = System.server + href;
-		} else {window.location = window.location;}
+		if (href) {location.href = System.server + href;
+		} else {location.reload();}
 	},
 
 	resetLevelFilter: function(evt) {
@@ -8825,8 +8849,8 @@ var Helper = {
 		document.getElementById('Helper.' + minLvlSearchText).value=1;
 		System.setValue(maxLvlSearchText, 9999);
 		document.getElementById('Helper.' + maxLvlSearchText).value=9999;
-		if (href) {window.location = System.server + href;
-		} else {window.location = window.location;}
+		if (href) {location.href = System.server + href;
+		} else {location.reload();}
 	},
 
 	addEventSortArena: function() {
@@ -8852,7 +8876,7 @@ var Helper = {
 
 	hideMatchesForCompletedMoves: function(evt) {
 		System.setValue('hideMatchesForCompletedMoves', evt.target.checked);
-		window.location=window.location;
+		location.reload();
 	},
 
 	sortArena: function(evt) {
@@ -9124,7 +9148,7 @@ var Helper = {
 					System.xmlhttp('index.php?cmd=arena&subcmd=dopickmove&move_id='+mv[i]+'&slot_id='+i);
 				}
 			}
-			setTimeout(function() {window.location = window.location;}, 500);
+			setTimeout(function() {location.reload();}, 500);
 		}, 500);
 	},
 
@@ -9547,13 +9571,13 @@ var Helper = {
 				theMap.levels = {};
 				System.setValueJSON('map', theMap);
 			}
-			window.location.reload();
+			location.reload();
 		}
 	},
 
 	updateFpColor: function() {
 		System.setValue('footprintsColor', System.findNode('//input[@name="footprintsColor"]').value);
-		window.location.reload();
+		location.reload();
 	},
 
 	helpLink: function(title, text) {
@@ -9598,7 +9622,7 @@ var Helper = {
 		Data.saveBoxes.forEach(System.saveValueForm, oForm);
 
 		window.alert('FS Helper Settings Saved');
-		window.location.reload();
+		location.reload();
 		return false;
 	},
 
@@ -9678,7 +9702,7 @@ var Helper = {
 		if (window.confirm('Are you sure you want to clear your log?')) {
 			// var combatLog=document.getElementById('Helper:CombatLog');
 			System.setValue('CombatLog', '');
-			window.location = window.location;
+			location.reload();
 		}
 	},
 
@@ -9834,7 +9858,7 @@ var Helper = {
 		var currentPos = '('+Helper.moveList[id].X+', '+Helper.moveList[id].Y+')';
 		if (responseText.indexOf(currentPos)<0) {
 			alert('Cannot move via ' + currentPos);
-			window.location = window.location;
+			location.reload();
 		} else {
 			// update current pos
 			Helper.markPosOnMiniMap(Helper.moveList[id]);
@@ -9847,7 +9871,7 @@ var Helper = {
 						Helper.moveList[nextId].Y,
 					Helper.autoMoveNext,
 					nextId);
-			} else { window.location = window.location;}
+			} else {location.reload();}
 		}
 	},
 
@@ -9922,7 +9946,7 @@ var Helper = {
 		if (!dirButton) {return;}
 		var url = dirButton.getAttribute('onClick');
 		url = url.replace(/^[^']*'/m, '').replace(/\';$/m, '');
-		window.location = url;
+		location.href = url;
 	},
 
 	injectInvent: function(){
@@ -10267,7 +10291,7 @@ var Helper = {
 		} else {
 		System.setValue('questBeingTracked', location.search);
 		}
-		window.location = window.location;
+		location.reload();
 	},
 
 	dontTrackThisQuest: function(evt) {
@@ -10289,7 +10313,7 @@ var Helper = {
 		System.setValue('questBeingTracked', '');
 		}
 
-		window.location = window.location;
+		location.reload();
 	},
 
 	getQuestInfo: function(responseText, callback) {
@@ -10521,7 +10545,7 @@ var Helper = {
 
 	resetBountyList: function() {
 		System.setValueJSON('bountylist', null);
-		window.location = window.location;
+		location.reload();
 	},
 
 	injectWantedList: function(wantedList) {
@@ -10584,7 +10608,7 @@ var Helper = {
 
 	resetWantedList: function() {
 		System.setValueJSON('wantedList', null);
-		window.location = window.location;
+		location.reload();
 	},
 
 	prepareAllyEnemyList: function() {
@@ -10822,7 +10846,7 @@ var Helper = {
 
 	resetAllyEnemyList: function() {
 		System.setValue('contactList','');
-		window.location = window.location;
+		location.reload();
 	},
 
 	toggleCheckAllPlants: function(evt) {
@@ -11373,7 +11397,7 @@ var Helper = {
 
 	resetNewGuildLog: function() {
 		System.setValueJSON('storedGuildLog', '');
-		window.location = window.location;
+		location.reload();
 	},
 
 	toggleGuildLogFilterVisibility: function(evt) {
@@ -11741,7 +11765,7 @@ displayDisconnectedFromGodsMessage: function() {
 
 	injectUpgradeAlert: function() { //jquery
 		//if (!System.getValue('enableUpgradeAlert')) {return;}
-		if (window.location.search.search('cmd=points&type=1') !== -1) {return;}
+		if (location.search.search('cmd=points&type=1') !== -1) {return;}
 		var needToDoUpgrade = System.getValue('needToDoUpgrade');
 		if (needToDoUpgrade) {
 			Helper.displayUpgradeMsg();
@@ -11755,7 +11779,7 @@ displayDisconnectedFromGodsMessage: function() {
 	parseGoldUpgrades: function(data) { //jquery
 		if (!System.getValue('enableUpgradeAlert')) {return;}
 		var doc;
-		if (window.location.search.search('cmd=points&type=1') === -1) {
+		if (location.search.search('cmd=points&type=1') === -1) {
 			doc = data;
 		} else {
 			doc = document;
@@ -12224,7 +12248,7 @@ displayDisconnectedFromGodsMessage: function() {
 	useStairs: function() { //jquery
 		//cmd=world&subcmd=usestairs&stairway_id=1645&x=6&y=11
 		$('input[name="stairway_id"]:first').each(function(){
-			window.location='index.php?cmd=world&subcmd=usestairs&' +
+			location.href = 'index.php?cmd=world&subcmd=usestairs&' +
 				'stairway_id=' + $(this).val();
 		});
 	},
@@ -12444,7 +12468,7 @@ displayDisconnectedFromGodsMessage: function() {
 				}
 				if ($('select[id^="composing-template-"]').length === 0 &&
 					$('div#helperQCError').length === 0) {
-					window.location = 'index.php?cmd=composing&m=0';
+					location.href = 'index.php?cmd=composing&m=0';
 				}
 			}
 		});

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -8858,10 +8858,14 @@ var Helper = {
 		var href = evt.target.getAttribute('href');
 		var minLvlSearchText = filterSubject + 'MinLvl';
 		var maxLvlSearchText = filterSubject + 'MaxLvl';
-		var playerMinLvl = document.getElementById('Helper.' + minLvlSearchText);
-		var playerMaxLvl = document.getElementById('Helper.' + maxLvlSearchText);
-		if (playerMinLvl.value === '') {playerMinLvl.value = '0';}
-		if (playerMaxLvl.value === '') {playerMaxLvl.value = '9999';}
+		var playerMinLvl = document.getElementById('Helper.' +
+			minLvlSearchText);
+		var playerMaxLvl = document.getElementById('Helper.' +
+			maxLvlSearchText);
+		if (playerMinLvl.value === '') {
+				playerMinLvl.value = Data.defaults[minLvlSearchText];}
+		if (playerMaxLvl.value === '') {
+				playerMaxLvl.value = Data.defaults[maxLvlSearchText];}
 		if (!isNaN(playerMinLvl.value)) {
 			System.setValue(minLvlSearchText, parseInt(playerMinLvl.value, 10));
 		}
@@ -8877,10 +8881,12 @@ var Helper = {
 		var href = evt.target.getAttribute('href');
 		var minLvlSearchText = filterSubject + 'MinLvl';
 		var maxLvlSearchText = filterSubject + 'MaxLvl';
-		System.setValue(minLvlSearchText, 1);
-		document.getElementById('Helper.' + minLvlSearchText).value=1;
+		System.setValue(minLvlSearchText, Data.defaults[minLvlSearchText]);
+		document.getElementById('Helper.' + minLvlSearchText).value =
+			Data.defaults[minLvlSearchText];
 		System.setValue(maxLvlSearchText, 9999);
-		document.getElementById('Helper.' + maxLvlSearchText).value=9999;
+		document.getElementById('Helper.' + maxLvlSearchText).value =
+			Data.defaults[maxLvlSearchText];
 		if (href) {location.href = System.server + href;
 		} else {location.reload();}
 	},

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -6097,6 +6097,12 @@ var Helper = {
 
 		var allItems = targetInventory.items;
 		var xcNum;
+		if (reportType === 'guild') {
+			xcNum = System.getValue('goldConfirm');
+		} else {
+			xcNum = Helper.inventory.xc;
+			System.setValue('goldConfirm', xcNum);
+		}
 
 		var minLvl = parseInt($('input[id="Helper.inventoryMinLvl"]').attr('value'), 10);
 		var maxLvl = parseInt($('input[id="Helper.inventoryMaxLvl"]').attr('value'), 10);
@@ -6115,74 +6121,67 @@ var Helper = {
 			var whereTitle='';
 			var whereText='';
 			var p=0;
-			xcNum = System.getValue('goldConfirm');
 			if (reportType === 'guild') {
-				if(item.player_id===-1){ //guild store
-					item.player_name='GS';
-					color = 'navy';   whereText = 'GS';   whereTitle='Guild Store';
-				}else{
-					item.player_name=targetInventory.members[item.player_id];
+				if (item.player_id === -1) { //guild store
+					item.player_name = 'GS';
+					color = 'navy';   whereText = 'GS';   whereTitle = 'Guild Store';
+				} else {
+					item.player_name = targetInventory.members[item.player_id];
 					color = 'maroon'; whereText = item.player_name;  whereTitle='Guild Report';
 				}
-				if(item.player_id===-1){
-					p=targetInventory.guild_id;
-					t=4;
-				}else{
-					p=item.player_id;
-					t=1;
+				if (item.player_id===-1) {
+					p = targetInventory.guild_id;
+					t = 4;
+				} else {
+					p = item.player_id;
+					t = 1;
 				}
-				p=p+'&currentPlayerId='+targetInventory.current_player_id;
+				p = p + '&currentPlayerId=' + targetInventory.current_player_id;
 			}else{
-				xcNum=Helper.inventory.xc;
-				System.setValue('goldConfirm', xcNum);
 				if(item.equipped){
-					color = 'green';  whereText = 'Worn'; whereTitle='Wearing it';
+					color = 'green';  whereText = 'Worn'; whereTitle = 'Wearing it';
 				}else{
-					color = 'blue';   whereText = Helper.inventory.folders[item.folder_id];   whereTitle='In Backpack';
+					color = 'blue';   whereText = Helper.inventory.folders[item.folder_id];   whereTitle = 'In Backpack';
 				}
-				p=targetInventory.player_id;
-				t=1;
+				p = targetInventory.player_id;
+				t = 1;
 			}
 
+			var rarity = Data.rarityColour[item.rarity];
+
 			var nm = item.item_name;
-			if(item.equipped) { nm='<b>'+nm+'</b>';}
-			result+='<tr style="color:'+ color +'">' +
+			if (item.equipped) { nm = '<b>' + nm + '</b>';}
+			result += '<tr style="color:' + color + '">' +
 				'<td>' + //'<img src="' + System.imageServerHTTP + '/temple/1.gif" onmouseover="' + item.onmouseover + '">' +
-				'</td><td><a style="cursor:help" id="Helper:item'+i+'" arrayID="'+i+'" class="tip-dynamic" ' +
-				'data-tipped="fetchitem.php?item_id='+item.item_id+'&inv_id='+item.inv_id+'&t='+t+'&p='+p+'">' + nm + '</a>';
+				'</td><td><a style="cursor:help; color:' + rarity +
+				'" id="Helper:item' + i +
+				'" arrayID="' + i + '" class="tip-dynamic" ' +
+				'data-tipped="fetchitem.php?item_id=' + item.item_id +
+				'&inv_id=' + item.inv_id + '&t=' + t + '&p=' + p + '">' + nm +
+				'</a>';
 
 			if (item.stats.set_name && reportType === 'guild') {
 				result+=' (<a href="/index.php?cmd=guild&subcmd=inventory&subcmd2=report&set=' +
 					item.item_name.replace(/(amulet)|(armor)|(armored)|(axe)|(boots)|(fist)|(gauntlets)|(gloves)|(hammer)|(helm)|(helmet)|(mace)|(necklace)|(of)|(plate)|(ring)|(rune)|(shield)|(sword)|(the)|(weapon)|/gi,'').trim().replace(/  /g,' ').replace(/  /g,' ').replace(/ /g,'|') + '">set</a>)';
 			}
-			var craftColor = '';
-			switch(item.craft) {
-				case 'Perfect': craftColor = '#00b600'; break;
-				case 'Excellent': craftColor = '#f6ed00'; break;
-				case 'Very Good': craftColor = '#f67a00'; break;
-				case 'Good': craftColor = '#f65d00'; break;
-				case 'Average': craftColor = '#f64500'; break;
-				case 'Poor': craftColor = '#f61d00'; break;
-				case 'Very Poor': craftColor = '#b21500'; break;
-				case 'Uncrafted': craftColor = '#666666'; break;
-			}
+
+			var craftColor = Data.craft[item.craft] ?
+				Data.craft[item.craft].colour : '';
 
 			var durabilityPercent = '';
 			var durabilityColor;
 			if (item.durability) {
-				//~ var durabilityExec = /(.*)\/(.*)/.exec(item.durability);
 				durabilityPercent = parseInt(100*item.durability/item.max_durability,10);
 				item.durabilityPer=durabilityPercent;
 				durabilityColor = durabilityPercent < 20 ?'red':'gray';
 			}
 
 // TODO
-			var itemTypes=new Array('Helmet','Armor','Gloves','Boots','Weapon','Shield','Ring','Amulet','Rune');
 
 			result+='</td>' +
 				'<td align="right">' + item.stats.min_level + '</td>' +
 				'<td align="left" title="' + whereTitle + '">' + whereText + '</td>' +
-				'<td align="left">' + itemTypes[item.type] + '</td>' +
+				'<td align="left">' + Data.itemType[item.type] + '</td>' +
 				'<td align="right">' + item.stats.attack + '</td>' +
 				'<td align="right">' + item.stats.defense + '</td>' +
 				'<td align="right">' + item.stats.armor + '</td>' +
@@ -12544,9 +12543,9 @@ displayDisconnectedFromGodsMessage: function() {
 
 (function loadScripts () {
 	var o = {
-		css: ['https://fallenswordhelper.github.io/fallenswordhelper/resources/1505/calfSystem.css'],
+		css: ['https://fallenswordhelper.github.io/fallenswordhelper/resources/1507/calfSystem.css'],
 		js:  ['https://cdn.jsdelivr.net/localforage/1.2.7/localforage.min.js',
-			  'https://fallenswordhelper.github.io/fallenswordhelper/resources/1505/calfSystem.js'],
+			  'https://fallenswordhelper.github.io/fallenswordhelper/resources/1507/calfSystem.js'],
 		callback: Helper.onPageLoad
 	};
 	if (typeof window.jQuery === 'undefined') {

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -8662,6 +8662,7 @@ var Helper = {
 			var maxAuctionsValue = maxAuctionsValueRE.exec(maxAuctionsRatio.innerHTML)[1]*1;
 			System.setValue('maxAuctions',maxAuctionsValue+2);
 		}
+		Helper.injectPoints();
 	},
 
 	injectTopRated: function() {
@@ -10173,7 +10174,7 @@ var Helper = {
 	},
 
 	injectPoints: function() {
-		Helper.currentFSP = System.findNode('//tr[td/a/img[contains(@src,"/skin/icon_points.gif")]]/td[4]').textContent.replace(/,/g,'')*1;
+		Helper.currentFSP = System.intValue($('dt#statbar-fsp').text().replace(/,/g, ''));
 
 		var stamForFSPElement = System.findNode('//td[@width="60%" and contains(.,"+25 Current Stamina")]/../td[4]');
 		var stamForFSPInjectHere = System.findNode('//td[@width="60%" and contains(.,"+25 Current Stamina")]');

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -9,7 +9,7 @@
 // @include        http://local.huntedcow.com/fallensword/*
 // @exclude        http://forum.fallensword.com/*
 // @exclude        http://wiki.fallensword.com/*
-// @version        1507b2
+// @version        1507b3
 // @downloadURL    https://fallenswordhelper.github.io/fallenswordhelper/Releases/Beta/fallenswordhelper.user.js
 // @grant          none
 // ==/UserScript==
@@ -6485,7 +6485,7 @@ var Helper = {
 			var tds = $('td', $(this));
 			var player = tds.eq(1).text();
 			if (Helper.onlinePlayers[player] &&
-				Helper.onlinePlayers[player][3] < thePage) {return;}
+				Helper.onlinePlayers[player][3] > thePage) {return;}
 			Helper.onlinePlayers[player] = [
 				tds.eq(0).html(),
 				tds.eq(1).html(),
@@ -6566,7 +6566,7 @@ var Helper = {
 					$('td', row).eq(2).addClass('lvlHighlight');
 				}
 			},
-			order: [3, 'asc']
+			order: [3, 'desc']
 		}).api();
 
 		Helper.doOnlinePlayerEventHandlers(table);

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -7188,6 +7188,22 @@ var Helper = {
 		System.xmlhttp('index.php?cmd=profile', Helper.getSustain);
 		$('div#packs').on('click', 'h1', window.updateCost);
 		$('div#players').on('click', 'h1', Helper.addBuffLevels);
+		var excludeBuff = {
+			'skill-50': 'Death Dealer',
+			'skill-54': 'Counter Attack',
+			'skill-55': 'Summon Shield Imp',
+			'skill-56': 'Vision',
+			'skill-60': 'Nightmare Visage',
+			'skill-61': 'Quest Finder',
+			'skill-98': 'Barricade',
+			'skill-101': 'Severe Condition'};
+		$('div#buff-outer label').each(function() {
+			var lbl = $(this);
+			var myLvl = parseInt($('span > span', lbl)
+				.text().replace(/\[|\]/g, ''), 10);
+			if (!excludeBuff[lbl.attr('for')] && myLvl < 125) {
+				lbl.addClass('fshDim');}
+		});
 	},
 
 	addBuffLevels: function() {


### PR DESCRIPTION
A few more major enhancements here. Probably the most interesting is the
restoration of some more Quickbuff functionality. I say restoration, obviously
it had to be completely recoded for the new interface. Buff packs will now
update stam cost correctly when selected. When you select a player from the
target player list you will see the levels on their existing buffs in either
red or green next to your buff list. I hope this makes sense to everyone! Also
I have added last activity and stamina to the right of the player. The old
Quickbuff showed their statistics block from their profile but I don't think
we have room for that and it is a slow operation so I have decided not to do it
for now. If anyone really wants to see it we can discuss it here.
Online players has been completely refactored. Please take a look at it. I have
no idea if anyone actually uses it but this at least removes massive amounts of
old code while maintaining functionality.
There is a new composing alert for the composers among you. Let me know what
you think. I'm not happy with the alert wording.
Colour coding items in inventory manager especially for UrcK ;)

==Revision 1507 (PointyHair)==
  \# (major) FS: Refactor online players
  \# (major) FS: Quickbuff enhancements
  \# (major) FS: Manage backpack screen converted to QTip2
  \# (major) FS: Composing alert
  \# (minor) FS: Colour coding items in inventory manager
  \# (minor) FS: Fix FSP upgrades page
  \# (minor) FS: Add member count to groups
  \# (minor) FS: storage usage in settings