### PR TITLE
Upgrade Page Switcher

### DIFF
--- a/calfSystem.css
+++ b/calfSystem.css
@@ -34,6 +34,7 @@
 .fshCrystal   {color: #6633ff;}
 .fshEpic      {color: #00cc00;}
 
+.fshCenter    {text-align: center;}
 
 .fshNoWrap {white-space: nowrap;}
 .helperQC  {cursor: pointer;}
@@ -76,6 +77,10 @@ div#fshCompConf {
   text-align: right;
   padding-right: 38px;
 }
+
+table.fshInvFilter {width: 100%;}
+
+table.fshInvFilter th {background-color: #cd9e4b;}
 
 /*
  * Table styles
@@ -158,12 +163,12 @@ table.dataTable tbody tr {
 table.dataTable tbody tr.selected {
   background-color: #B0BED9;
 }
+/*
 table.dataTable tbody th,
 table.dataTable tbody td {
-/*
   padding: 8px 10px;
-*/
 }
+*/
 table.dataTable.row-border tbody th, table.dataTable.row-border tbody td, table.dataTable.display tbody th, table.dataTable.display tbody td {
   border-top: 1px solid #ddd;
 }

--- a/calfSystem.js
+++ b/calfSystem.js
@@ -987,6 +987,8 @@ window.Data = {
 		needToCompose: false,
 		lastComposeCheck: 0,
 		lastOnlineCheck: 0,
+		bountyList: '',
+		wantedList: '',
 
 /* jshint -W110 */ // Mixed double and single quotes. (W110)
 
@@ -1193,7 +1195,108 @@ window.Data = {
 		{colour: '#cc0033', class: 'fshSuper'},
 		{colour: '#6633ff', class: 'fshCrystal'},
 		{colour: '#009900', class: 'fshEpic'}
-	]
+	],
+
+	pageSwitcher: {
+		settings: {'-': {'-': {'-': 'injectSettings'}}},
+		world: {
+			'-': {'-': {'-': 'injectWorld'}},
+			'viewcreature': {'-': {'-': 'injectCreature'}},
+			'map': {'-': {'-': 'injectWorldMap'}}},
+		news: {
+			'fsbox': {'-': {'-': 'newsFsbox'}},
+			'shoutbox': {'-': {'-': 'newsShoutbox'}}},
+		//blacksmith: {'repairall': {'-': {'-': 'injectWorld'}}},
+		arena: {
+			//'-': {'-': {'-': 'injectArena'}},
+			'completed': {'-': {'-': 'storeCompletedArenas'}},
+			'pickmove': {'-': {'-': 'storeArenaMoves'}},
+			//'results': {'-': {'-': 'injectTournament'}},
+			//'dojoin': {'-': {'-': 'injectTournament'}},
+			'setup': {'-': {'-': 'injectArenaSetupMove'}}},
+		questbook: {
+			'-': {'-': {'-': 'injectQuestBookFull'}},
+			'atoz': {'-': {'-': 'injectQuestBookFull'}},
+			'viewquest': {'-': {'-':'injectQuestTracker'}}},
+		profile: {
+			'-': {'-': {'-': 'injectProfile'}},
+			'changebio': {'-': {'-': 'injectBioWidgets'}},
+			'dropitems': {'-': {'-': 'injectProfileDropItems'}}},
+		auctionhouse: {'-': {'-': {'-': 'injectAuctionHouse'}}},
+		guild: {
+			'inventory': {
+				'report': {'-': 'injectReportPaint'},
+				'addtags': {'-': 'injectGuildAddTagsWidgets'},
+				'removetags': {'-': 'injectGuildAddTagsWidgets'},
+				'storeitems': {'-': 'injectDropItems'}},
+			'chat': {'-': {'-': 'guildChat'}},
+			'log': {'-': {'-': 'guildLog'}},
+			'groups': {
+				'viewstats': {'-': 'injectGroupStats'},
+				'-': {'-': 'injectGroups'}},
+			'manage': {'-': {'-': 'injectGuild'}},
+			'advisor': {'-': {'-': 'injectAdvisor'}},
+			'history': {'-': {'-': 'addHistoryWidgets'}},
+			'view': {'-': {'-': 'injectViewGuild'}},
+			'scouttower': {'-': {'-': 'injectScouttower'}},
+			'mailbox': {'-': {'-': 'injectMailbox'}},
+			'ranks': {'-': {'-': 'injectGuildRanks'}},
+			'conflicts': {'rpupgrades': {'-': 'injectRPUpgrades'}}},
+		bank: {'-': {'-': {'-': 'injectBank'}}},
+		log: {
+			'-': {'-': {
+				'-': 'playerLog',
+				'-1': 'playerLog',
+				'0': 'playerLog',
+				'1': 'playerLog',
+				'2': 'playerLog',
+				'3': 'playerLog'}},
+			'outbox': {'-': {'-': 'outbox'}}},
+		potionbazaar: {'-': {'-': {'-': 'injectBazaar'}}},
+		marketplace: {
+			'createreq': {'-': {'-': 'addMarketplaceWidgets'}}},
+		quickbuff: {'-': {'-': {'-': 'injectQuickBuff'}}},
+		notepad: {
+			'showlogs': {'-': {'-': 'injectNotepadShowLogs'}},
+			'invmanagernew': {'-': {'-': 'injectInventoryManagerNew'}},
+			'invmanager': {'-': {'-': 'injectInventoryManager'}},
+			'guildinvmgr': {'-': {'-': 'injectInventoryManagerNew'}},
+			'guildinvmanager': {'-': {'-': 'injectInventoryManager'}},
+			'recipemanager': {'-': {'-': 'injectRecipeManager'}},
+			'auctionsearch': {'-': {'-': 'injectAuctionSearch'}},
+			'onlineplayers': {'-': {'-': 'injectOnlinePlayers'}},
+			'quicklinkmanager': {'-': {'-': 'injectQuickLinkManager'}},
+			'monsterlog': {'-': {'-': 'injectMonsterLog'}},
+			'quickextract': {'-': {'-': 'insertQuickExtract'}},
+			'quickwear': {'-': {'-': 'insertQuickWear'}},
+			'fsboxcontent': {'-': {'-': 'injectFsBoxContent'}},
+			'bufflogcontent': {'-': {'-': 'injectBuffLog'}},
+			'newguildlog': {'-': {'-': 'injectNewGuildLog'}},
+			'findbuffs': {'-': {'-': 'injectFindBuffs'}},
+			'findother': {'-': {'-': 'injectFindOther'}},
+			'savesettings': {'-': {'-': 'injectSaveSettings'}},
+			'-': {'-': {'-': 'injectNotepad'}}},
+		points: {'-': {'-': {
+			'-': 'storePlayerUpgrades',
+			'0': 'storePlayerUpgrades',
+			'1': 'parseGoldUpgrades'}}},
+		trade: {
+			'-': {'-': {'-': 'injectTrade'}},
+			'createsecure': {'-': {'-': 'injectTrade'}}},
+		titan: {'-': {'-': {'-': 'injectTitan'}}},
+		toprated: {'xp': {'-': {'-': 'injectTopRated'}}},
+		inventing: {'viewrecipe': {'-': {'-': 'inventing'}}},
+		tempinv: {'-': {'-': {'-': 'injectMailbox'}}},
+		//attackplayer: {'-': {'-': {'-': 'injectAttackPlayer'}}},
+		findplayer: {'-': {'-': {'-': 'injectFindPlayer'}}},
+		//relic: {'-': {'-': {'-': 'injectRelic'}}},
+		quests: {'view': {'-': {'-': 'showAllQuestSteps'}}},
+		scavenging: {'process': {'-': {'-': 'injectScavenging'}}},
+		temple: {'-': {'-': {'-': 'parseTemplePage'}}},
+		skills: {'-': {'-': {'-': 'injectSkills'}}},
+		composing: {'-': {'-': {'-': 'injectComposing'}}},
+		'-': {'-': {'-': {'-': 'unknownPage'}}}
+	}
 
 };
 

--- a/calfSystem.js
+++ b/calfSystem.js
@@ -1215,7 +1215,10 @@ window.Data = {
 			//'dojoin': {'-': {'-': 'injectTournament'}},
 			'setup': {'-': {'-': 'injectArenaSetupMove'}}},
 		questbook: {
-			'-': {'-': {'-': 'injectQuestBookFull'}},
+			'-': {'-': {
+				'-': 'injectQuestBookFull',
+				'0': 'injectQuestBookFull', // Normal
+				'1': 'injectQuestBookFull'}}, // Seasonal
 			'atoz': {'-': {'-': 'injectQuestBookFull'}},
 			'viewquest': {'-': {'-':'injectQuestTracker'}}},
 		profile: {
@@ -1290,7 +1293,7 @@ window.Data = {
 		//attackplayer: {'-': {'-': {'-': 'injectAttackPlayer'}}},
 		findplayer: {'-': {'-': {'-': 'injectFindPlayer'}}},
 		//relic: {'-': {'-': {'-': 'injectRelic'}}},
-		quests: {'view': {'-': {'-': 'showAllQuestSteps'}}},
+		quests: {'view': {'-': {'-': 'showAllQuestSteps'}}}, //UFSG
 		scavenging: {'process': {'-': {'-': 'injectScavenging'}}},
 		temple: {'-': {'-': {'-': 'parseTemplePage'}}},
 		skills: {'-': {'-': {'-': 'injectSkills'}}},

--- a/calfSystem.js
+++ b/calfSystem.js
@@ -1206,7 +1206,7 @@ window.Data = {
 		news: {
 			'fsbox': {'-': {'-': 'newsFsbox'}},
 			'shoutbox': {'-': {'-': 'newsShoutbox'}}},
-		//blacksmith: {'repairall': {'-': {'-': 'injectWorld'}}},
+		blacksmith: {'repairall': {'-': {'-': 'injectWorld'}}},
 		arena: {
 			//'-': {'-': {'-': 'injectArena'}},
 			'completed': {'-': {'-': 'storeCompletedArenas'}},

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -4975,21 +4975,30 @@ var Helper = {
 	},
 
 	moveItemsToFolder: function() { // jquery
+		var batchSize = 200;
 		var invList = [];
-		$('input[name="removeIndex[]"]:checked').each(function() {
-			invList.push($(this).val());
+		$('input[name="removeIndex[]"]:checked').each(function(i) {
+			batchNo = Math.floor(i / batchSize);
+			invList[batchNo] = invList[batchNo] || [];
+			invList[batchNo].push($(this).val());
 		});
-		$.ajax({
-			dataType: 'json',
-			url: 'index.php',
-			data: {
-				'cmd': 'profile',
-				'subcmd': 'sendtofolder',
-				'inv_list': JSON.stringify(invList),
-				'folder_id': $('#selectFolderId option:selected').val(),
-				'ajax': 1
-			},
-			success: function(data) {location.reload();}
+		Helper.moveItemsCallback = invList.length;
+		invList.forEach(function(val) {
+			$.ajax({
+				dataType: 'json',
+				url: 'index.php',
+				data: {
+					'cmd': 'profile',
+					'subcmd': 'sendtofolder',
+					'inv_list': JSON.stringify(val),
+					'folder_id': $('#selectFolderId option:selected').val(),
+					'ajax': 1
+				},
+				success: function(data) {
+					Helper.moveItemsCallback -= 1;
+					if (Helper.moveItemsCallback === 0) {location.reload();}
+				}
+			});
 		});
 	},
 

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -1652,15 +1652,14 @@ var Helper = {
 		var counterAttackLevel;
 		var doublerLevel;
 
-		var buffHash = Helper.oldRemoveBuffs;
+		var buffHash = Helper.oldRemoveBuffs();
 
 		//extra world screen text
 		var replacementText = '<td background="' + System.imageServer +
-			'/skin/realm_right_bg.jpg">';
-		replacementText += '<table align="right" cellpadding="1" style="' +
-			'width:270px;margin-left:38px;margin-right:38px;font-size:medium' +
-			'; border-spacing: 1px; border-collapse: collapse;">';
-		replacementText += '<tr><td colspan="2" height="10"></td></tr><tr>';
+			'/skin/realm_right_bg.jpg"><table align="right" cellpadding="1" ' +
+			'style="width:270px;margin-left:38px;margin-right:38px;font-size' +
+			':medium; border-spacing: 1px; border-collapse: collapse;"><tr><' +
+			'td colspan="2" height="10"></td></tr><tr>';
 		var hasShieldImp = System
 			.findNode('//img[contains(@src,"/55_sm.gif")]');
 		var hasDeathDealer = System
@@ -1694,46 +1693,7 @@ var Helper = {
 				'blue;cursor:pointer;text-decoration:underline;font-size:' +
 				'xx-small;">Recast</span>':'') + '</td></tr>';
 			if (hasDeathDealer) {
-				if (System.getValue('lastDeathDealerPercentage') === undefined) {
-					System.setValue('lastDeathDealerPercentage', 0);}
-				if (System.getValue('lastKillStreak') === undefined) {
-					System.setValue('lastKillStreak', 0);}
-				var lastDeathDealerPercentage =
-					System.getValue('lastDeathDealerPercentage');
-				var lastKillStreak = System.getValue('lastKillStreak');
-				if (impsRemaining > 0 && lastDeathDealerPercentage === 20) {
-					replacementText += '<tr><td style="font-size:small; ' +
-						'color:black">Kill Streak: <span findme="killstreak">' +
-						'&gt;' + System.addCommas(lastKillStreak) + '</span> ' +
-						'Damage bonus: <span findme="damagebonus">20</span>%' +
-						'</td></tr>';
-				} else {
-					if (!System.getValue('trackKillStreak')) {
-						replacementText += '<tr><td style="font-size:small; ' +
-							'color:navy" nowrap>KillStreak tracker disabled. ' +
-							'<span style="font-size:xx-small">Track: <span ' +
-							'id=Helper:toggleKStracker style="color:navy;' +
-							'cursor:pointer;text-decoration:underline;" ' +
-							'title="Click to toggle">' +
-							(System.getValue('trackKillStreak') ? 'ON' : 'off') +
-							'</span></span></td></tr>';
-					} else {
-						replacementText += '<tr><td style="font-size:small;' +
-							' color:navy" nowrap>KillStreak: <span findme="' +
-							'killstreak">' + System.addCommas(lastKillStreak) +
-							'</span> Damage bonus: <span findme="damagebonus' +
-							'">' + Math.round(lastDeathDealerPercentage *
-							100) / 100 + '</span>%&nbsp;' + '<span style="' +
-							'font-size:xx-small">Track: <span id=Helper:' +
-							'toggleKStracker style="color:navy;cursor:' +
-							'pointer;text-decoration:underline;" title="' +
-							'Click to toggle">'+
-							(System.getValue('trackKillStreak') ? 'ON' : 'off') +
-							'</span></span></td></tr>';
-						System.xmlhttp('index.php?cmd=profile',
-							Helper.getKillStreak);
-					}
-				}
+				replacementText += Helper.doDeathDealer(impsRemaining);
 			}
 		}
 		var hasCounterAttack = System
@@ -1822,6 +1782,55 @@ var Helper = {
 		}
 
 		Helper.toggleKsTracker();
+	},
+
+	doDeathDealer: function(impsRemaining) {
+		var replacementText = '';
+
+		var lastDeathDealerPercentage =
+			System.getValue('lastDeathDealerPercentage');
+		if (lastDeathDealerPercentage === undefined) {
+			System.setValue('lastDeathDealerPercentage', 0);
+			lastDeathDealerPercentage = 0;
+		}
+
+		var lastKillStreak = System.getValue('lastKillStreak');
+		if (lastKillStreak === undefined) {
+			System.setValue('lastKillStreak', 0);
+			lastKillStreak = 0;
+		}
+
+		var trackKillStreak = System.getValue('trackKillStreak');
+
+		if (impsRemaining > 0 && lastDeathDealerPercentage === 20) {
+			replacementText += '<tr><td style="font-size:small; color:black"' +
+				'>Kill Streak: <span findme="killstreak">&gt;' +
+				System.addCommas(lastKillStreak) + '</span> Damage bonus: <' +
+				'span findme="damagebonus">20</span>%</td></tr>';
+		} else {
+			if (!trackKillStreak) {
+				replacementText += '<tr><td style="font-size:small; color:' +
+					'navy" nowrap>KillStreak tracker disabled. <span style="' +
+					'font-size:xx-small">Track: <span id=Helper:toggleKS' +
+					'tracker style="color:navy;cursor:pointer;text-' +
+					'decoration:underline;" title="Click to toggle">' +
+					(trackKillStreak ? 'ON' : 'off') +
+					'</span></span></td></tr>';
+			} else {
+				replacementText += '<tr><td style="font-size:small; color:' +
+					'navy" nowrap>KillStreak: <span findme="killstreak">' +
+					System.addCommas(lastKillStreak) + '</span> Damage bonus' +
+					': <span findme="damagebonus">' +
+					Math.round(lastDeathDealerPercentage * 100) / 100 +
+					'</span>%&nbsp;<span style="font-size:xx-small">Track: ' +
+					'<span id=Helper:toggleKStracker style="color:navy;' +
+					'cursor:pointer;text-decoration:underline;" title="Click' +
+					' to toggle">' + (trackKillStreak ? 'ON' : 'off') +
+					'</span></span></td></tr>';
+				System.xmlhttp('index.php?cmd=profile', Helper.getKillStreak);
+			}
+		}
+		return replacementText;
 	},
 
 	toggleKsTracker: function() {

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -2592,13 +2592,6 @@ var Helper = {
 		Helper.showMap(true);
 	},
 
-	//retrieveTradeConfirm: function() {
-		//var xcNumber = $('input[name="xc"]').val() || '-';
-		//xcNumber=System.findNode('//input[@type="hidden" and @name="xc"]');
-		//xcNumber=xcNumber?xcNumber.getAttribute('value'):'-';
-		//System.setValue('goldConfirm', xcNumber);
-	//},
-
 	sendGoldToPlayer: function(){
 //		var injectHere = System.findNode('//div[table[@class="centered" and @style="width: 270px;"]]');
 //		if (!injectHere) {return;}
@@ -4816,8 +4809,11 @@ var Helper = {
 	},
 
 	injectProfile: function() {
+		var qb = $('div#profileRightColumn a:contains("Quick Buff")');
+		qb.attr('href', qb.attr('href').replace(/500/g,'1000'));
 
-		var charStats = $('#profileLeftColumn table').first().attr('id', 'characterStats');
+		var charStats = $('#profileLeftColumn table').first()
+			.attr('id', 'characterStats');
 		var tblCells = $('td', charStats).has('table').has('font');
 		tblCells.each(function(i, e) {
 			var tde = $('td', e);

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -12133,9 +12133,9 @@ displayDisconnectedFromGodsMessage: function() {
 
 (function loadScripts () {
 	var o = {
-		css: ['https://fallenswordhelper.github.io/fallenswordhelper/resources/1507/calfSystem.css'],
+		css: ['https://fallenswordhelper.github.io/fallenswordhelper/resources/1509/calfSystem.css'],
 		js:  ['https://cdn.jsdelivr.net/localforage/1.2.10/localforage.min.js',
-			  'https://fallenswordhelper.github.io/fallenswordhelper/resources/1507/calfSystem.js'],
+			  'https://fallenswordhelper.github.io/fallenswordhelper/resources/1509/calfSystem.js'],
 		callback: Helper.onPageLoad
 	};
 	if (typeof window.jQuery === 'undefined') {

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -9,7 +9,7 @@
 // @include        http://local.huntedcow.com/fallensword/*
 // @exclude        http://forum.fallensword.com/*
 // @exclude        http://wiki.fallensword.com/*
-// @version        1509b3
+// @version        1509b4
 // @downloadURL    https://fallenswordhelper.github.io/fallenswordhelper/Releases/Beta/fallenswordhelper.user.js
 // @grant          none
 // ==/UserScript==
@@ -79,446 +79,41 @@ var Helper = {
 			Helper.prepareEnv();
 		}
 
-		var pageId, subPageId, subPage2Id, subsequentPageId, typePageId;
+		var pageId;
+		var subPageId;
+		var subPage2Id;
+		var typePageId;
+		var funcName;
+		var fn;
 
 		if (document.location.search !== '') {
-			var re=/cmd=([a-z]+)/;
-			var pageIdRE = re.exec(document.location.search);
-			pageId='-';
-			if (pageIdRE) {pageId=pageIdRE[1];}
-
-			re=/subcmd=([a-z]+)/;
-			var subPageIdRE = re.exec(document.location.search);
-			subPageId='-';
-			if (subPageIdRE){subPageId=subPageIdRE[1];}
-			re=/subcmd2=([a-z]+)/;
-			var subPage2IdRE = re.exec(document.location.search);
-			subPage2Id='-';
-			if (subPage2IdRE) {subPage2Id=subPage2IdRE[1];}
-
-			re=/page=([0-9]+)/;
-			var subsequentPageIdRE = re.exec(document.location.search);
-			subsequentPageId='-';
-			if (subsequentPageIdRE) {subsequentPageId=subsequentPageIdRE[1];}
-
-			re=/type=([0-9]+)/;
-			var typePageIdRE = re.exec(document.location.search);
-			typePageId='-';
-			if (typePageIdRE) {typePageId=typePageIdRE[1];}
+			pageId = System.getUrlParameter('cmd') || '-';
+			subPageId = System.getUrlParameter('subcmd') || '-';
+			subPage2Id = System.getUrlParameter('subcmd2') || '-';
+			typePageId = System.getUrlParameter('type') || '-';
 		} else {
-			pageId=System.findNode('//input[@type="hidden" and @name="cmd"]');
-			pageId = pageId?pageId.getAttribute('value'):'-';
-
-			subPageId=System.findNode('//input[@type="hidden" and @name="subcmd"]');
-			subPageId=subPageId?subPageId.getAttribute('value'):'-';
-			if (subPageId==='dochat') {pageId='-'; subPageId='-';}
-
-			subPage2Id=System.findNode('//input[@type="hidden" and @name="subcmd2"]');
-			subPage2Id=subPage2Id?subPage2Id.getAttribute('value'):'-';
-
-			subsequentPageId=System.findNode('//input[@type="hidden" and @name="page"]');
-			subsequentPageId=subsequentPageId?subsequentPageId.getAttribute('value'):'-';
+			pageId = $('input[name="cmd"]').val() || '-';
+			subPageId = $('input[name="subcmd"]').val() || '-';
+			if (subPageId==='dochat') {
+				pageId='-';
+				subPageId='-';
+			}
+			subPage2Id = $('input[name="subcmd2"]').val() || '-';
+			typePageId = '-';
 		}
 
-		Helper.page = pageId + '/' + subPageId + '/' + subPage2Id + '(' + subsequentPageId + ')';
+		Helper.page = pageId + '/' + subPageId + '/' + subPage2Id + '(' + typePageId + ')';
 
-		switch (pageId) {
-		case 'settings':
-			Helper.injectSettings();
-			break;
-		case 'world':
-			switch (subPageId) {
-			case 'viewcreature':
-				Helper.injectCreature();
-				break;
-			case 'map':
-				Helper.injectWorldMap();
-				break;
-			default:
-				Helper.injectWorld();
-				break;
-			}
-			break;
-		case 'news':
-			switch (subPageId) {
-			case 'fsbox':
-				Helper.injectShoutboxWidgets('fsbox_input', 100);
-				break;
-			case 'shoutbox':
-				Helper.injectShoutboxWidgets('shoutbox_input', 150);
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'blacksmith':
-			switch (subPageId) {
-			case 'repairall':
-				Helper.injectWorld();
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'arena':
-			switch (subPageId) {
-			case '-':
-				// Helper.injectArena();
-				break;
-			case 'completed':
-				Helper.storeCompletedArenas();
-				break;
-			case 'pickmove':
-				Helper.storeArenaMoves();
-				break;
-			case 'results':
-				// Helper.injectTournament();
-				break;
-			case 'dojoin':
-				// Helper.injectTournament();
-				break;
-			case 'setup':
-				Helper.injectArenaSetupMove();
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'questbook':
-			switch (subPageId) {
-			case 'viewquest':
-				Helper.injectQuestTracker();
-				break;
-			case 'atoz':
-				Helper.injectQuestBookFull();
-				break;
-			case '-':
-				Helper.injectQuestBookFull();
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'profile':
-			switch (subPageId) {
-			case 'dropitems':
-				Helper.injectDropItems();
-				Helper.injectMoveItems();
-				break;
-			case 'changebio':
-				Helper.injectBioWidgets();
-				break;
-			case '-':
-				Helper.injectProfile();
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'auctionhouse':
-			Helper.injectAuctionHouse();
-			break;
-		case 'guild':
-			switch (subPageId) {
-			case 'inventory':
-				switch (subPage2Id) {
-					case 'report':
-						Helper.injectReportPaint();
-						break;
-					case 'addtags':
-						Helper.injectGuildAddTagsWidgets();
-						break;
-					case 'removetags':
-						Helper.injectGuildAddTagsWidgets();
-						break;
-					case 'storeitems':
-						Helper.injectDropItems();
-						break;
-					default:
-						break;
-				}
-				break;
-			case 'chat':
-				Helper.addChatTextArea();
-				Helper.addLogColoring('Chat', 0);
-				break;
-			case 'log':
-				Helper.addLogColoring('GuildLog', 1);
-				Helper.addGuildLogWidgets();
-				break;
-			case 'groups':
-				switch (subPage2Id) {
-					case 'viewstats':
-						Helper.injectGroupStats();
-						break;
-					default:
-						Helper.injectGroups();
-						break;
-				}
-				break;
-			case 'manage':
-				Helper.injectGuild();
-				break;
-			case 'advisor':
-				Helper.injectAdvisor();
-				break;
-			case 'history':
-				Helper.addHistoryWidgets();
-				break;
-			case 'view':
-				Helper.injectViewGuild();
-				break;
-			case 'scouttower':
-				Helper.injectScouttower();
-				break;
-			case 'mailbox':
-				Helper.injectMailbox();
-				break;
-			case 'ranks':
-				Helper.injectGuildRanks();
-				break;
-			case 'conflicts':
-				switch (subPage2Id) {
-					case 'rpupgrades':
-						Helper.injectRPUpgrades();
-						break;
-					default:
-						break;
-				}
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'bank':
-			Helper.injectBank();
-			break;
-		case 'log':
-			switch (subPageId) {
-			case 'outbox':
-				Helper.addLogColoring('OutBox', 1);
-				break;
-			case '-':
-				Helper.addLogColoring('PlayerLog', 1);
-				Helper.addLogWidgets();
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'potionbazaar':
-			Helper.injectBazaar();
-			break;
-		case 'marketplace':
-			switch (subPageId) {
-			case 'createreq':
-				Helper.addMarketplaceWidgets();
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'quickbuff':
-			Helper.injectQuickBuff();
-			break;
-		case 'notepad':
-			switch (subPageId) {
-			case 'showlogs':
-				Helper.injectNotepadShowLogs();
-				break;
-			case 'invmanager':
-				Helper.injectInventoryManager();
-				break;
-			case 'guildinvmanager':
-				Helper.injectInventoryManager();
-				break;
-			case 'recipemanager':
-				Helper.injectRecipeManager();
-				break;
-			case 'auctionsearch':
-				Helper.injectAuctionSearch();
-				break;
-			case 'onlineplayers':
-				Helper.injectOnlinePlayers();
-				break;
-			case 'quicklinkmanager':
-				Helper.injectQuickLinkManager();
-				break;
-			case 'monsterlog':
-				Helper.injectMonsterLog();
-				break;
-			case 'quickextract':
-				Helper.insertQuickExtract();
-				break;
-			case 'quickwear':
-				Helper.insertQuickWear();
-				break;
-			case 'fsboxcontent':
-				Helper.injectFsBoxContent();
-				break;
-			case 'bufflogcontent':
-				Helper.injectBuffLog();
-				break;
-			case 'newguildlog':
-				Helper.injectNewGuildLog();
-				break;
-			case 'findbuffs':
-				Helper.injectFindBuffs();
-				break;
-			case 'findother':
-				Helper.injectFindOther();
-				break;
-			case 'createmap':
-				break;
-			case 'savesettings':
-				Helper.injectSaveSettings();
-				break;
-			default:
-				Helper.injectNotepad();
-				break;
-			}
-			break;
-		case 'points':
-			switch (subPageId) {
-			case '-': // Ignore guild upgrades
-				switch (typePageId) {
-				case '-':
-					Helper.storePlayerUpgrades();
-					break;
-				case '0':
-					Helper.storePlayerUpgrades();
-					break;
-				case '1':
-					Helper.parseGoldUpgrades();
-					break;
-				default:
-					break;
-				}
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'trade':
-			Helper.retrieveTradeConfirm();
-			switch (subPageId) {
-			case 'createsecure':
-				Helper.injectTrade();
-				break;
-			case '-':
-				Helper.injectTrade();
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'titan':
-			Helper.injectTitan();
-			break;
-		case 'toprated':
-			switch (subPageId) {
-			case 'xp':
-				Helper.injectTopRated();
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'inventing':
-			switch (subPageId) {
-			case 'viewrecipe':
-				Helper.injectViewRecipe();
-				Helper.injectInvent();
-				break;
-			default:
-				break;
-			}
-			// Helper.injectInvent();
-			break;
-		case 'tempinv':
-			Helper.injectMailbox();
-			break;
-		case 'attackplayer':
-			Helper.injectAttackPlayer();
-			break;
-		case 'findplayer':
-			Helper.injectFindPlayer();
-			break;
-		case 'relic':
-			Helper.injectRelic();
-			break;
-		case 'creatures':
-			switch (subPageId) {
-			case 'view':
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'quests':
-			switch (subPageId) {
-			case 'view':
-				Helper.showAllQuestSteps();
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'scavenging':
-			switch (subPageId) {
-			case 'process':
-				Helper.injectScavenging();
-				break;
-			default:
-				break;
-			}
-			break;
-		case 'temple':
-			Helper.parseTemplePage();
-			break;
-		case '-':
-			var isRelicPage = System.findNode('//td[contains(.,"Below is the current status for the relic")]/b');
-			if (isRelicPage) {
-				Helper.injectRelic();
-			}
-			var isBuffResult = System.findNode('//td[contains(.,"Back to Quick Buff Menu")]');
-			if (isBuffResult) {
-				Helper.updateBuffLog();
-			}
-			var isShopPage =  $('#shop-info').length > 0;//System.findNode('//td[contains(.,"then click to purchase for the price listed below the item.")]');
-			if (isShopPage) {
-				Helper.injectShop();
-			}
-			var isQuestBookPage = System.findNode('//td[.="Quest Name"]');
-			if (isQuestBookPage) {
-				Helper.injectQuestBookFull();
-			}
-			var isAdvisorPageClue1 = System.findNode('//font[@size=2 and .="Advisor"]');
-			var clue2 = '//a[@href="index.php?cmd=guild&amp;subcmd=manage" and .="Back to Guild Management"]';
-			var isAdvisorPageClue2 = System.findNode(clue2);
-			if (isAdvisorPageClue1 && isAdvisorPageClue2) {
-				Helper.injectAdvisor(subPage2Id);
-			}
-			// var isArenaTournamentPage = System.findNode('//b[contains(.,"Tournament #")]');
-			// if (isArenaTournamentPage) {
-				// Helper.injectTournament();
-			// }
-			if (System.findNode('//a[.="Back to Scavenging"]')) {
-				Helper.injectScavenging();
-			}
-			if ($('img[title="Inventing"]').length > 0) {
-				Helper.injectInvent();
-			}
-			break;
-		case 'skills':
-			//Helper.injectSkillsPage();
-			break;
-		case 'composing':
-			Helper.injectComposing();
-			break;
-		default:
-			break;
+		if (Data.pageSwitcher[pageId] &&
+			Data.pageSwitcher[pageId][subPageId] &&
+			Data.pageSwitcher[pageId][subPageId][subPage2Id] &&
+			Data.pageSwitcher[pageId][subPageId][subPage2Id][typePageId]) {
+			funcName = Data.pageSwitcher[pageId][subPageId][subPage2Id]
+				[typePageId];
+			fn = Helper[funcName];
+			fn();
 		}
+
 		if (System.getValue('playNewMessageSound')) {
 			var soundLocation = System.getValue('defaultMessageSound');
 			//new UI
@@ -535,6 +130,82 @@ var Helper = {
 		// This must be at the end in order not to screw up other System.findNode calls (Issue 351)
 		if (System.getValue('huntingMode') === false) {
 			Helper.injectQuickLinks();
+		}
+	},
+
+	newsFsbox: function() {
+		Helper.injectShoutboxWidgets('fsbox_input', 100);
+	},
+
+	newsShoutbox: function() {
+		Helper.injectShoutboxWidgets('shoutbox_input', 150);
+	},
+
+	injectProfileDropItems: function() {
+		Helper.injectDropItems();
+		Helper.injectMoveItems();
+	},
+
+	guildChat: function() {
+		Helper.addChatTextArea();
+		Helper.addLogColoring('Chat', 0);
+	},
+
+	guildLog: function() {
+		Helper.addLogColoring('GuildLog', 1);
+		Helper.addGuildLogWidgets();
+	},
+
+	outbox: function() {
+		Helper.addLogColoring('OutBox', 1);
+	},
+
+	playerLog: function() {
+		Helper.addLogColoring('PlayerLog', 1);
+		Helper.addLogWidgets();
+	},
+
+	inventing: function() {
+		Helper.injectViewRecipe();
+		Helper.injectInvent();
+	},
+
+	unknownPage: function() {
+		console.log('*** unknownPage ***');
+		//var isRelicPage = $('div#pCC td:contains("Below is the current status for the relic")');
+		//var isRelicPage = System.findNode('//td[contains(.,"Below is the current status for the relic")]/b');
+		if ($('div#pCC td:contains("Below is the current status for ' +
+			'the relic")').length > 0) {
+			Helper.injectRelic();
+		}
+		var isBuffResult = System.findNode('//td[contains(.,"Back to Quick Buff Menu")]');
+		if (isBuffResult) {
+			Helper.updateBuffLog();
+		}
+		//System.findNode('//td[contains(.,"then click to purchase for the price listed below the item.")]');
+		//var isShopPage =  $('#shop-info').length > 0;
+		if ($('#shop-info').length > 0) {
+			Helper.injectShop();
+		}
+		var isQuestBookPage = System.findNode('//td[.="Quest Name"]');
+		if (isQuestBookPage) {
+			Helper.injectQuestBookFull();
+		}
+		var isAdvisorPageClue1 = System.findNode('//font[@size=2 and .="Advisor"]');
+		var clue2 = '//a[@href="index.php?cmd=guild&amp;subcmd=manage" and .="Back to Guild Management"]';
+		var isAdvisorPageClue2 = System.findNode(clue2);
+		if (isAdvisorPageClue1 && isAdvisorPageClue2) {
+			Helper.injectAdvisor();
+		}
+		// var isArenaTournamentPage = System.findNode('//b[contains(.,"Tournament #")]');
+		// if (isArenaTournamentPage) {
+			// Helper.injectTournament();
+		// }
+		if (System.findNode('//a[.="Back to Scavenging"]')) {
+			Helper.injectScavenging();
+		}
+		if ($('div#pCC img[title="Inventing"]').length > 0) {
+			Helper.injectInvent();
 		}
 	},
 
@@ -2912,12 +2583,12 @@ var Helper = {
 		Helper.showMap(true);
 	},
 
-	retrieveTradeConfirm: function() {
-		var xcNumber;
-		xcNumber=System.findNode('//input[@type="hidden" and @name="xc"]');
-		xcNumber=xcNumber?xcNumber.getAttribute('value'):'-';
-		System.setValue('goldConfirm', xcNumber);
-	},
+	//retrieveTradeConfirm: function() {
+		//var xcNumber = $('input[name="xc"]').val() || '-';
+		//xcNumber=System.findNode('//input[@type="hidden" and @name="xc"]');
+		//xcNumber=xcNumber?xcNumber.getAttribute('value'):'-';
+		//System.setValue('goldConfirm', xcNumber);
+	//},
 
 	sendGoldToPlayer: function(){
 //		var injectHere = System.findNode('//div[table[@class="centered" and @style="width: 270px;"]]');

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -4810,7 +4810,9 @@ var Helper = {
 
 	injectProfile: function() {
 		var qb = $('div#profileRightColumn a:contains("Quick Buff")');
-		qb.attr('href', qb.attr('href').replace(/500/g,'1000'));
+		if (qb.length !== 0) {
+			qb.attr('href', qb.attr('href').replace(/500/g,'1000'));
+		}
 
 		var charStats = $('#profileLeftColumn table').first()
 			.attr('id', 'characterStats');

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -4975,7 +4975,7 @@ var Helper = {
 	},
 
 	moveItemsToFolder: function() { // jquery
-		var batchSize = 200;
+		var batchSize = 50;
 		var invList = [];
 		$('input[name="removeIndex[]"]:checked').each(function(i) {
 			batchNo = Math.floor(i / batchSize);

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -9,7 +9,7 @@
 // @include        http://local.huntedcow.com/fallensword/*
 // @exclude        http://forum.fallensword.com/*
 // @exclude        http://wiki.fallensword.com/*
-// @version        1509b1
+// @version        1509b2
 // @downloadURL    https://fallenswordhelper.github.io/fallenswordhelper/Releases/Beta/fallenswordhelper.user.js
 // @grant          none
 // ==/UserScript==

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -9,7 +9,7 @@
 // @include        http://local.huntedcow.com/fallensword/*
 // @exclude        http://forum.fallensword.com/*
 // @exclude        http://wiki.fallensword.com/*
-// @version        1509b4
+// @version        1509b5
 // @downloadURL    https://fallenswordhelper.github.io/fallenswordhelper/Releases/Beta/fallenswordhelper.user.js
 // @grant          none
 // ==/UserScript==
@@ -5763,6 +5763,8 @@ var Helper = {
 			'<th width="10"></th>';
 		var item, color;
 
+		Helper.disableItemColoring = System.getValue('disableItemColoring');
+
 		var allItems = targetInventory.items;
 		var xcNum;
 		if (reportType === 'guild') {
@@ -5815,13 +5817,14 @@ var Helper = {
 				t = 1;
 			}
 
-			var rarity = Data.rarity[item.rarity].colour;
+			var rarity = Helper.disableItemColoring ? '' : ' color:' +
+				Data.rarity[item.rarity].colour;
 
 			var nm = item.item_name;
 			if (item.equipped) { nm = '<b>' + nm + '</b>';}
 			result += '<tr style="color:' + color + '">' +
 				'<td>' + //'<img src="' + System.imageServerHTTP + '/temple/1.gif" onmouseover="' + item.onmouseover + '">' +
-				'</td><td><a style="cursor:help; color:' + rarity +
+				'</td><td><a style="cursor:help;' + rarity +
 				'" id="Helper:item' + i +
 				'" arrayID="' + i + '" class="tip-dynamic" ' +
 				'data-tipped="fetchitem.php?item_id=' + item.item_id +

--- a/fallenswordhelper.user.js
+++ b/fallenswordhelper.user.js
@@ -9,7 +9,7 @@
 // @include        http://local.huntedcow.com/fallensword/*
 // @exclude        http://forum.fallensword.com/*
 // @exclude        http://wiki.fallensword.com/*
-// @version        1509b2
+// @version        1509b3
 // @downloadURL    https://fallenswordhelper.github.io/fallenswordhelper/Releases/Beta/fallenswordhelper.user.js
 // @grant          none
 // ==/UserScript==
@@ -4975,10 +4975,9 @@ var Helper = {
 	},
 
 	moveItemsToFolder: function() { // jquery
-		var batchSize = 50;
 		var invList = [];
 		$('input[name="removeIndex[]"]:checked').each(function(i) {
-			batchNo = Math.floor(i / batchSize);
+			var batchNo = Math.floor(i / 50);
 			invList[batchNo] = invList[batchNo] || [];
 			invList[batchNo].push($(this).val());
 		});
@@ -4994,7 +4993,7 @@ var Helper = {
 					'folder_id': $('#selectFolderId option:selected').val(),
 					'ajax': 1
 				},
-				success: function(data) {
+				success: function() {
 					Helper.moveItemsCallback -= 1;
 					if (Helper.moveItemsCallback === 0) {location.reload();}
 				}
@@ -7240,6 +7239,7 @@ var Helper = {
 			if (!excludeBuff[lbl.attr('for')] && myLvl < 125) {
 				lbl.addClass('fshDim');}
 		});
+		$('div#players h1').first().click();
 	},
 
 	addBuffLevels: function() {


### PR DESCRIPTION
OK this release has a brand new page switcher. It's how FSH knows which page you are looking at and what to do with it. The main reason I did it was to make it easier to manage in future. There is a theoretical performance improvement. I doubt you will notice it on modern machines but older machines and mobile browsers definitely benefit.
We're preselecting the first player in the quickbuff window to more closely mirror previous FSH functionality.
I've done a quick fix for wanted bounties. I am aware of some issues with it. It needs to be revisited in future.

==Revision 1509 (PointyHair)==
 \# (major) FS: Upgrade page switcher
 \# (minor) FS: Update Move Items in BackPack screen #66
 \# (minor) FS: Preselect first target player in quickbuff
 \# (minor) FS: Fix wanted bounties (part 1)
 \# (minor) FS: Item coloring preference in Inventory Manager #31
 \# (minor) FS: fix quick buff link in profile
 \# (minor) FS: Fix Upgrade page for flash sales