### PR TITLE
Added check for image load fail on creature pages of UFSG

### DIFF
--- a/src/modules/chrome/pageSwitcher/creatures.js
+++ b/src/modules/chrome/pageSwitcher/creatures.js
@@ -1,0 +1,9 @@
+import runDefault from '../../common/runDefault';
+import { ufsgAllowBack } from './loader';
+
+const imgFix = () => { runDefault(import('../../guide/imgFix')); };
+
+export default {
+  '-': { '-': ufsgAllowBack },
+  view: { '-': imgFix },
+};

--- a/src/modules/chrome/pageSwitcher/pageSwitcher.js
+++ b/src/modules/chrome/pageSwitcher/pageSwitcher.js
@@ -1,6 +1,7 @@
 import arena from './arena';
 import auctionhouse from './auctionhouse';
 import composing from './composing';
+import creatures from './creatures';
 import guild from './guild/guild';
 import injectWorld from '../../world/injectWorld';
 import items from './items';
@@ -63,7 +64,7 @@ export default {
   findplayer: { '-': { '-': injectFindPlayer } },
   quests, // UFSG
   items, // UFSG
-  creatures: { '-': { '-': ufsgAllowBack } }, // UFSG
+  creatures, // UFSG
   masterrealms: { '-': { '-': ufsgAllowBack } }, // UFSG
   realms: { '-': { '-': ufsgAllowBack } }, // UFSG
   relics: { '-': { '-': ufsgAllowBack } }, // UFSG

--- a/src/modules/chrome/pageSwitcher/pageSwitcher.js
+++ b/src/modules/chrome/pageSwitcher/pageSwitcher.js
@@ -65,10 +65,10 @@ export default {
   quests, // UFSG
   items, // UFSG
   creatures, // UFSG
-  masterrealms: { '-': { '-': ufsgAllowBack } }, // UFSG
+  masterrealms: creatures, // UFSG
   realms: { '-': { '-': ufsgAllowBack } }, // UFSG
   relics: { '-': { '-': ufsgAllowBack } }, // UFSG
-  shops: { '-': { '-': ufsgAllowBack } }, // UFSG
+  shops: creatures, // UFSG
   scavenging,
   temple: { '-': { '-': parseTemplePage } },
   composing,

--- a/src/modules/guide/imgFix.js
+++ b/src/modules/guide/imgFix.js
@@ -1,20 +1,26 @@
 import getElementsByTagName from '../common/getElementsByTagName';
-import on from '../common/on';
+import once from '../common/once';
 
 function isBroken(img) {
   return img.complete && img.naturalHeight === 0;
 }
 
 function imgToPng(img) {
-  const root = img.src.substring(0, img.src.length - 4);
-  return `${root}.png`;
+  return img.src
+    .replace(
+      /^http:\/\/cdn\.fallensword\.com\/skin\/gold_button\.gif$/,
+      'https://cdn2.fallensword.com/currency/0.png',
+    ) // shop currency images
+    .replace(/\.jpg$/, '.png') // creature & master realm image
+    .replace(/^http:/, 'https:') // creature image
+    .replace(/\.gif$/, '.png'); // master realm images
 }
 
 export default function imgFix() {
   const imgs = getElementsByTagName('img');
   for (const img of imgs) {
     // Before image load
-    on(img, 'error', () => { img.src = imgToPng(img); });
+    once(img, 'error', () => { img.src = imgToPng(img); });
     // After image load
     if (isBroken(img)) { img.src = imgToPng(img); }
   }

--- a/src/modules/guide/imgFix.js
+++ b/src/modules/guide/imgFix.js
@@ -1,0 +1,21 @@
+import getElementsByTagName from '../common/getElementsByTagName';
+import on from '../common/on';
+
+function isBroken(img) {
+  return img.complete && img.naturalHeight === 0;
+}
+
+function imgToPng(img) {
+  const root = img.src.substring(0, img.src.length - 4);
+  return `${root}.png`;
+}
+
+export default function imgFix() {
+  const imgs = getElementsByTagName('img');
+  for (const img of imgs) {
+    // Before image load
+    on(img, 'error', () => { img.src = imgToPng(img); });
+    // After image load
+    if (isBroken(img)) { img.src = imgToPng(img); }
+  }
+}


### PR DESCRIPTION
Fixes issue on creature pages of UFSG. HSC converted a lot of the JPGs to PNGs, but never fixed the img src attributes.

I had thought this issue extended to items as well. But after a second look, I wasn't able to find any examples of it.