### PR TITLE
Fsp market max

### DIFF
--- a/src/modules/marketplace.js
+++ b/src/modules/marketplace.js
@@ -93,6 +93,7 @@ function addMaxBtn(input, btn) {
 }
 
 function addMaxButtons() {
+  if (!getAmount() || !getPrice()) return;
   const maxFsp = makeMaxButton();
   onclick(maxFsp, () => maxInput(getAmount(), getPrice()));
   addMaxBtn(getAmount(), maxFsp);


### PR DESCRIPTION
Added a couple buttons on creating FSP marketplace listings. They auto-fill either the gold or FSP amount to match however much gold the player has on hand.