### PR TITLE
Fix guild tracker not creating daily records

### DIFF
--- a/src/modules/notepad/guildTracker/memberDataProcessor.js
+++ b/src/modules/notepad/guildTracker/memberDataProcessor.js
@@ -79,9 +79,11 @@ function processMemberDataUpdate(member, prof, history) {
     );
   } else {
     // Significant changes detected - check if record is over 24 hours old
-    const recordCreationTime = lastRecord?.[created] || lastRecord?.[utc]; // Fallback to utc for old records
-    const timeSinceRecordCreation = recordCreationTime ? realtimeSecs() - recordCreationTime : Infinity;
-    const recordIsOld = timeSinceRecordCreation > SECONDS_PER_DAY;
+    // Don't fallback to utc - if created doesn't exist, treat as old to create a proper new record
+    const recordCreationTime = lastRecord?.[created];
+    const recordIsOld =
+      !recordCreationTime ||
+      realtimeSecs() - recordCreationTime > SECONDS_PER_DAY;
 
     if (recordIsOld) {
       // Create new record


### PR DESCRIPTION
Legacy records without the 'created' field (added in #853) were falling back to 'utc' for the 24-hour check. Since 'utc' gets updated on every check, these records were never considered old enough to trigger new daily records.

Remove the fallback - if 'created' doesn't exist, treat the record as old so a new record with proper 'created' timestamp gets created.