### PR TITLE
Fix guild tracker logging using wrong timestamp field

### DIFF
--- a/src/modules/notepad/guildTracker/waitTimeCalculator.js
+++ b/src/modules/notepad/guildTracker/waitTimeCalculator.js
@@ -6,7 +6,7 @@ import {
 } from '../../support/constants';
 import devStdOut from '../../support/devStdOut';
 import { realtimeSecs } from '../../support/now';
-import { created, utc } from './indexConstants';
+import { utc } from './indexConstants';
 import { getMembersNeedingUpdate } from './memberDataProcessor';
 
 function formatDuration(milliseconds) {
@@ -26,8 +26,8 @@ function findOldestMemberUpdateTime(guildData, currentMemberNames) {
 
       if (history.length > 0) {
         const lastRecord = history.at(-1);
-        // Use created time for age check, fallback to utc for old records
-        const memberUpdateTime = lastRecord[created] || lastRecord[utc];
+        // Use utc (last verification time) to determine when member was last checked
+        const memberUpdateTime = lastRecord[utc];
         if (!oldestUpdateTime || memberUpdateTime < oldestUpdateTime) {
           oldestUpdateTime = memberUpdateTime;
         }


### PR DESCRIPTION
The wait time calculator was using 'created' (record creation time) to determine scheduling, but it should use 'utc' (last verification time).

- 'created' is for 24-hour record rotation
- 'utc' is for 6-hour check interval scheduling

This fixes the misleading "oldest update Xh ago" message.